### PR TITLE
Sends a ChatRoomHelp message when joining or creating a chatroom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# JetBrains
+.idea/
+
 node_modules
 log.txt
 restart.bat

--- a/app.js
+++ b/app.js
@@ -520,6 +520,7 @@ function ChatRoomCreate(data, socket) {
 				console.log("Chat room (" + ChatRoom.length.toString() + ") " + data.Name + " created by account " + Acc.AccountName + ", ID: " + socket.id.toString());
 				socket.emit("ChatRoomCreateResponse", "ChatRoomCreated");
 				ChatRoomSync(NewRoom, Acc.MemberNumber);
+				ChatRoomMessage(ChatRoom[C], Acc.MemberNumber, "ChatRoomHelp", "Action", Acc.MemberNumber);
 			} else socket.emit("ChatRoomCreateResponse", "AccountError");
 
 		} else socket.emit("ChatRoomCreateResponse", "InvalidRoomData");
@@ -554,6 +555,7 @@ function ChatRoomJoin(data, socket) {
 									ChatRoom[C].Account.push(Acc);
 									socket.emit("ChatRoomSearchResponse", "JoinedRoom");
 									ChatRoomSync(ChatRoom[C], Acc.MemberNumber);
+									ChatRoomMessage(ChatRoom[C], Acc.MemberNumber, "ChatRoomHelp", "Action", Acc.MemberNumber);
 									ChatRoomMessage(ChatRoom[C], Acc.MemberNumber, "ServerEnter", "Action", null, [{Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber}]);
 									return;
 								} else {


### PR DESCRIPTION
**Motivation**: I seem to spend quite a lot of time helping people with chatroom commands, and many people aren't aware of the `/help` command, so don't know how to look up commands themselves.

This change sends a `ChatRoomHelp` command whenever a player enters or creates a chatroom. This means that the `/help` command text will always be displayed upon entering a chatroom.

I've also added the `.idea` directory to `.gitignore`, as I use a JetBrains IDE.