### PR TITLE
Set title in online account list when updating title.

### DIFF
--- a/app.js
+++ b/app.js
@@ -339,6 +339,7 @@ function AccountUpdate(data, socket) {
 					}
 					delete data.Lover;
 				}
+				if ((data.Title != null)) Account[P].Title = data.Title;
 
 				// If we have data to push
 				if (!ObjectEmpty(data)) Database.collection("Accounts").updateOne({ AccountName : Account[P].AccountName }, { $set: data }, function(err, res) { if (err) throw err; });


### PR DESCRIPTION
Small bugfix in title sync.

When a player updates her title it gets saved in the DB but not in the online player list causing other players to see an outdated title in chat rooms.