### PR TITLE
Room search changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -484,7 +484,7 @@ function ChatRoomSearch(data, socket) {
 			// Builds a list of all public rooms, the last rooms created are shown first
 			var CR = [];
 			var C = 0;
-			for (var C = (ChatRoom.length - 1 - StartingRoom); ((C >= 0) && (CR.length <= NbRooms)); C--)
+			for (var C = ChatRoom.length - 1; ((C >= StartingRoom) && (CR.length <= NbRooms)); C--)
 				if (ChatRoom[C] != null && ((ShowFullRooms) || (ChatRoom[C].Account.length < ChatRoom[C].Limit)))
 					if ((Acc.Environment == ChatRoom[C].Environment) && (Space == ChatRoom[C].Space)) // Must be in same environment (prod/dev) and same space (hall/asylum)
 						if (ChatRoom[C].Ban.indexOf(Acc.MemberNumber) < 0) // The player cannot be banned

--- a/app.js
+++ b/app.js
@@ -472,11 +472,11 @@ function ChatRoomSearch(data, socket) {
 			var Space = "";
 			if ((data.Space != null) && (typeof data.Space === "string") && (data.Space.length <= 100)) Space = data.Space;
 
-			// Builds a list of up to 24 possible rooms, the last rooms created are shown first
+			// Builds a list of all public rooms, the last rooms created are shown first
 			var CR = [];
 			var C = 0;
-			for (var C = ChatRoom.length - 1; ((C >= 0) && (CR.length <= 24)); C--)
-				if ((ChatRoom[C] != null) && (ChatRoom[C].Account.length < ChatRoom[C].Limit))
+			for (var C = ChatRoom.length - 1; C >= 0; C--)
+				if (ChatRoom[C] != null)
 					if ((Acc.Environment == ChatRoom[C].Environment) && (Space == ChatRoom[C].Space)) // Must be in same environment (prod/dev) and same space (hall/asylum)
 						if (ChatRoom[C].Ban.indexOf(Acc.MemberNumber) < 0) // The player cannot be banned
 							if ((data.Query == "") || (ChatRoom[C].Name.toUpperCase().indexOf(data.Query) >= 0)) // Room name must contain the searched name, if any

--- a/app.js
+++ b/app.js
@@ -476,6 +476,14 @@ function ChatRoomSearch(data, socket) {
 			var FullRooms = false;
 			if ((data.FullRooms != null) && (typeof data.FullRooms === "boolean")) FullRooms = data.FullRooms;
 			
+			// Checks if the user opted to ignore certain rooms
+			var IgnoredRooms = [];
+			if ((data.Ignore != null) && (Array.isArray(data.Ignore))) IgnoredRooms = data.Ignore;
+			
+			// Validate array, only strings are valid.
+			var LN = /^[a-zA-Z0-9 ]+$/; 
+			IgnoredRooms = IgnoredRooms.filter(R => typeof R === "string" && R.match(LN));
+			
 			// Builds a list of all public rooms, the last rooms created are shown first
 			var CR = [];
 			var C = 0;
@@ -483,30 +491,32 @@ function ChatRoomSearch(data, socket) {
 				if ((ChatRoom[C] != null) && ((FullRooms) || (ChatRoom[C].Account.length < ChatRoom[C].Limit)))
 					if ((Acc.Environment == ChatRoom[C].Environment) && (Space == ChatRoom[C].Space)) // Must be in same environment (prod/dev) and same space (hall/asylum)
 						if (ChatRoom[C].Ban.indexOf(Acc.MemberNumber) < 0) // The player cannot be banned
-							if ((data.Query == "") || (ChatRoom[C].Name.toUpperCase().indexOf(data.Query) >= 0)) // Room name must contain the searched name, if any
-								if (!ChatRoom[C].Locked || (ChatRoom[C].Admin.indexOf(Acc.MemberNumber) >= 0)) // Must be unlocked, unless the player is an administrator
-									if (!ChatRoom[C].Private || (ChatRoom[C].Name.toUpperCase() == data.Query)) { // If it's private, must know the exact name
+							// Room name cannot be ignored
+							if (IgnoredRooms.indexOf(ChatRoom[C].Name.toUpperCase()) == -1)
+								if ((data.Query == "") || (ChatRoom[C].Name.toUpperCase().indexOf(data.Query) >= 0)) // Room name must contain the searched name, if any
+									if (!ChatRoom[C].Locked || (ChatRoom[C].Admin.indexOf(Acc.MemberNumber) >= 0)) // Must be unlocked, unless the player is an administrator
+										if (!ChatRoom[C].Private || (ChatRoom[C].Name.toUpperCase() == data.Query)) { // If it's private, must know the exact name
 
-										// Builds the searching account friend list in the current room
-										var Friends = [];
-										for (var A = 0; A < ChatRoom[C].Account.length; A++)
-											if (ChatRoom[C].Account[A] != null)
-												if ((ChatRoom[C].Account[A].Ownership != null) && (ChatRoom[C].Account[A].Ownership.MemberNumber != null) && (ChatRoom[C].Account[A].Ownership.MemberNumber == Acc.MemberNumber))
-													Friends.push({ Type: "Submissive", MemberNumber: ChatRoom[C].Account[A].MemberNumber, MemberName: ChatRoom[C].Account[A].Name});
-												else if ((Acc.FriendList != null) && (ChatRoom[C].Account[A].FriendList != null) && (Acc.FriendList.indexOf(ChatRoom[C].Account[A].MemberNumber) >= 0) && (ChatRoom[C].Account[A].FriendList.indexOf(Acc.MemberNumber) >= 0))
-													Friends.push({ Type: "Friend", MemberNumber: ChatRoom[C].Account[A].MemberNumber, MemberName: ChatRoom[C].Account[A].Name});
+											// Builds the searching account friend list in the current room
+											var Friends = [];
+											for (var A = 0; A < ChatRoom[C].Account.length; A++)
+												if (ChatRoom[C].Account[A] != null)
+													if ((ChatRoom[C].Account[A].Ownership != null) && (ChatRoom[C].Account[A].Ownership.MemberNumber != null) && (ChatRoom[C].Account[A].Ownership.MemberNumber == Acc.MemberNumber))
+														Friends.push({ Type: "Submissive", MemberNumber: ChatRoom[C].Account[A].MemberNumber, MemberName: ChatRoom[C].Account[A].Name});
+													else if ((Acc.FriendList != null) && (ChatRoom[C].Account[A].FriendList != null) && (Acc.FriendList.indexOf(ChatRoom[C].Account[A].MemberNumber) >= 0) && (ChatRoom[C].Account[A].FriendList.indexOf(Acc.MemberNumber) >= 0))
+														Friends.push({ Type: "Friend", MemberNumber: ChatRoom[C].Account[A].MemberNumber, MemberName: ChatRoom[C].Account[A].Name});
 
-										// Builds a room object with all data
-										CR.push({
-											Name: ChatRoom[C].Name,
-											Creator: ChatRoom[C].Creator,
-											MemberCount: ChatRoom[C].Account.length,
-											MemberLimit: ChatRoom[C].Limit,
-											Description: ChatRoom[C].Description,
-											Friends: Friends
-										});
+											// Builds a room object with all data
+											CR.push({
+												Name: ChatRoom[C].Name,
+												Creator: ChatRoom[C].Creator,
+												MemberCount: ChatRoom[C].Account.length,
+												MemberLimit: ChatRoom[C].Limit,
+												Description: ChatRoom[C].Description,
+												Friends: Friends
+											});
 
-									}
+										}
 
 			// Sends the list to the client
 			socket.emit("ChatRoomSearchResult", CR);

--- a/app.js
+++ b/app.js
@@ -472,11 +472,20 @@ function ChatRoomSearch(data, socket) {
 			var Space = "";
 			if ((data.Space != null) && (typeof data.Space === "string") && (data.Space.length <= 100)) Space = data.Space;
 
+			// Gets the search query options
+			var ShowFullRooms = false;
+			if ((data.ShowFullRooms != null) && (typeof data.ShowFullRooms === "boolean")) ShowFullRooms = data.ShowFullRooms;
+			var NbRooms = 24;
+			if ((data.NbRooms != null) && (typeof data.NbRooms === "number") && (data.NbRooms <= 24) && (data.NbRooms > 0)) NbRooms = data.NbRooms;
+			var StartingRoom = 0;
+			// We get the first page if the query is for an empty page
+			if ((data.StartingRoom != null) && (typeof data.StartingRoom === "number") && (data.StartingRoom >= 0) && (data.StartingRoom < ChatRoom.length)) StartingRoom = data.StartingRoom;
+			
 			// Builds a list of all public rooms, the last rooms created are shown first
 			var CR = [];
 			var C = 0;
-			for (var C = ChatRoom.length - 1; ((C >= 0) && (CR.length <= 60)); C--)
-				if (ChatRoom[C] != null)
+			for (var C = ChatRoom.length - 1; ((C >= StartingRoom) && (CR.length <= NbRooms)); C--)
+				if (ChatRoom[C] != null && ((ShowFullRooms) || (ChatRoom[C].Account.length < ChatRoom[C].Limit)))
 					if ((Acc.Environment == ChatRoom[C].Environment) && (Space == ChatRoom[C].Space)) // Must be in same environment (prod/dev) and same space (hall/asylum)
 						if (ChatRoom[C].Ban.indexOf(Acc.MemberNumber) < 0) // The player cannot be banned
 							if ((data.Query == "") || (ChatRoom[C].Name.toUpperCase().indexOf(data.Query) >= 0)) // Room name must contain the searched name, if any
@@ -505,7 +514,7 @@ function ChatRoomSearch(data, socket) {
 									}
 
 			// Sends the list to the client
-			socket.emit("ChatRoomSearchResult", CR);
+			socket.emit("ChatRoomSearchResult", { Result: CR, Total: ChatRoom.length });
 
 		}
 

--- a/app.js
+++ b/app.js
@@ -484,7 +484,7 @@ function ChatRoomSearch(data, socket) {
 			// Builds a list of all public rooms, the last rooms created are shown first
 			var CR = [];
 			var C = 0;
-			for (var C = ChatRoom.length - 1; ((C >= StartingRoom) && (CR.length <= NbRooms)); C--)
+			for (var C = (ChatRoom.length - 1 - StartingRoom); ((C >= 0) && (CR.length <= NbRooms)); C--)
 				if (ChatRoom[C] != null && ((ShowFullRooms) || (ChatRoom[C].Account.length < ChatRoom[C].Limit)))
 					if ((Acc.Environment == ChatRoom[C].Environment) && (Space == ChatRoom[C].Space)) // Must be in same environment (prod/dev) and same space (hall/asylum)
 						if (ChatRoom[C].Ban.indexOf(Acc.MemberNumber) < 0) // The player cannot be banned

--- a/app.js
+++ b/app.js
@@ -475,7 +475,7 @@ function ChatRoomSearch(data, socket) {
 			// Builds a list of all public rooms, the last rooms created are shown first
 			var CR = [];
 			var C = 0;
-			for (var C = ChatRoom.length - 1; C >= 0; C--)
+			for (var C = ChatRoom.length - 1; ((C >= 0) && (CR.length <= 60)); C--)
 				if (ChatRoom[C] != null)
 					if ((Acc.Environment == ChatRoom[C].Environment) && (Space == ChatRoom[C].Space)) // Must be in same environment (prod/dev) and same space (hall/asylum)
 						if (ChatRoom[C].Ban.indexOf(Acc.MemberNumber) < 0) // The player cannot be banned

--- a/app.js
+++ b/app.js
@@ -472,20 +472,11 @@ function ChatRoomSearch(data, socket) {
 			var Space = "";
 			if ((data.Space != null) && (typeof data.Space === "string") && (data.Space.length <= 100)) Space = data.Space;
 
-			// Gets the search query options
-			var ShowFullRooms = false;
-			if ((data.ShowFullRooms != null) && (typeof data.ShowFullRooms === "boolean")) ShowFullRooms = data.ShowFullRooms;
-			var NbRooms = 24;
-			if ((data.NbRooms != null) && (typeof data.NbRooms === "number") && (data.NbRooms <= 24) && (data.NbRooms > 0)) NbRooms = data.NbRooms;
-			var StartingRoom = 0;
-			// We get the first page if the query is for an empty page
-			if ((data.StartingRoom != null) && (typeof data.StartingRoom === "number") && (data.StartingRoom >= 0) && (data.StartingRoom < ChatRoom.length)) StartingRoom = data.StartingRoom;
-			
 			// Builds a list of all public rooms, the last rooms created are shown first
 			var CR = [];
 			var C = 0;
-			for (var C = ChatRoom.length - 1; ((C >= StartingRoom) && (CR.length <= NbRooms)); C--)
-				if (ChatRoom[C] != null && ((ShowFullRooms) || (ChatRoom[C].Account.length < ChatRoom[C].Limit)))
+			for (var C = ChatRoom.length - 1; ((C >= 0) && (CR.length <= 60)); C--)
+				if (ChatRoom[C] != null)
 					if ((Acc.Environment == ChatRoom[C].Environment) && (Space == ChatRoom[C].Space)) // Must be in same environment (prod/dev) and same space (hall/asylum)
 						if (ChatRoom[C].Ban.indexOf(Acc.MemberNumber) < 0) // The player cannot be banned
 							if ((data.Query == "") || (ChatRoom[C].Name.toUpperCase().indexOf(data.Query) >= 0)) // Room name must contain the searched name, if any
@@ -514,7 +505,7 @@ function ChatRoomSearch(data, socket) {
 									}
 
 			// Sends the list to the client
-			socket.emit("ChatRoomSearchResult", { Result: CR, Total: ChatRoom.length });
+			socket.emit("ChatRoomSearchResult", CR);
 
 		}
 

--- a/app.js
+++ b/app.js
@@ -491,12 +491,10 @@ function ChatRoomSearch(data, socket) {
 				if ((ChatRoom[C] != null) && ((FullRooms) || (ChatRoom[C].Account.length < ChatRoom[C].Limit)))
 					if ((Acc.Environment == ChatRoom[C].Environment) && (Space == ChatRoom[C].Space)) // Must be in same environment (prod/dev) and same space (hall/asylum)
 						if (ChatRoom[C].Ban.indexOf(Acc.MemberNumber) < 0) // The player cannot be banned
-							// Room name cannot be ignored
-							if (IgnoredRooms.indexOf(ChatRoom[C].Name.toUpperCase()) == -1)
-								if ((data.Query == "") || (ChatRoom[C].Name.toUpperCase().indexOf(data.Query) >= 0)) // Room name must contain the searched name, if any
-									if (!ChatRoom[C].Locked || (ChatRoom[C].Admin.indexOf(Acc.MemberNumber) >= 0)) // Must be unlocked, unless the player is an administrator
-										if (!ChatRoom[C].Private || (ChatRoom[C].Name.toUpperCase() == data.Query)) { // If it's private, must know the exact name
-
+							if ((data.Query == "") || (ChatRoom[C].Name.toUpperCase().indexOf(data.Query) >= 0)) // Room name must contain the searched name, if any
+								if (!ChatRoom[C].Locked || (ChatRoom[C].Admin.indexOf(Acc.MemberNumber) >= 0)) // Must be unlocked, unless the player is an administrator
+									if (!ChatRoom[C].Private || (ChatRoom[C].Name.toUpperCase() == data.Query)) // If it's private, must know the exact name
+										if (IgnoredRooms.indexOf(ChatRoom[C].Name.toUpperCase()) == -1) { // Room name cannot be ignored
 											// Builds the searching account friend list in the current room
 											var Friends = [];
 											for (var A = 0; A < ChatRoom[C].Account.length; A++)

--- a/app.js
+++ b/app.js
@@ -472,11 +472,15 @@ function ChatRoomSearch(data, socket) {
 			var Space = "";
 			if ((data.Space != null) && (typeof data.Space === "string") && (data.Space.length <= 100)) Space = data.Space;
 
+			// Checks if the user requested full rooms
+			var FullRooms = false;
+			if ((data.FullRooms != null) && (typeof data.FullRooms === "boolean")) FullRooms = data.FullRooms;
+			
 			// Builds a list of all public rooms, the last rooms created are shown first
 			var CR = [];
 			var C = 0;
 			for (var C = ChatRoom.length - 1; ((C >= 0) && (CR.length <= 60)); C--)
-				if (ChatRoom[C] != null)
+				if ((ChatRoom[C] != null) && ((FullRooms) || (ChatRoom[C].Account.length < ChatRoom[C].Limit)))
 					if ((Acc.Environment == ChatRoom[C].Environment) && (Space == ChatRoom[C].Space)) // Must be in same environment (prod/dev) and same space (hall/asylum)
 						if (ChatRoom[C].Ban.indexOf(Acc.MemberNumber) < 0) // The player cannot be banned
 							if ((data.Query == "") || (ChatRoom[C].Name.toUpperCase().indexOf(data.Query) >= 0)) // Room name must contain the searched name, if any


### PR DESCRIPTION
See the related client-side PR for the description.

This change is compatible with current version. No side effects should be seen.

## Highlights

Since the indentation changed and makes the diff look like a lot has changed and I know changing the server is a touchy subject, let me point out what lines I've added/modified here:

### Receiving a new optional full room boolean from the query
Here is where we acknowledge it and make it default to existing behavior. (Must be a bool)
```
var FullRooms = false;
if ((data.FullRooms != null) && (typeof data.FullRooms === "boolean")) FullRooms = data.FullRooms;
```

Here is the existing if statement modified to take it into account. (TRUE if show full rooms is true or if room is not full).
At this stage we know FullRooms is a boolean.
`if ((ChatRoom[C] != null) && ((FullRooms) || (ChatRoom[C].Account.length < ChatRoom[C].Limit)))`

### Room number
I have changed the query size limit on this line. (24 to 60)
`for (var C = ChatRoom.length - 1; ((C >= 0) && (CR.length <= 60)); C--)`

### Receiving a new ignored room string array from the query
We default to an empty array, if  we received an array, we clean it by making sure we only received an array of string and valid room names.
```
var IgnoredRooms = [];
if ((data.Ignore != null) && (Array.isArray(data.Ignore))) IgnoredRooms = data.Ignore;
var LN = /^[a-zA-Z0-9 ]+$/; 
IgnoredRooms = IgnoredRooms.filter(R => typeof R === "string" && R.match(LN));
```

We check if the name was ignored in the search loop. If the name of the room is not found, we continue.
This prevents your search from having less than the maximum amount of room if you hide too many rooms (like troll spam rooms).
At this stage, we know IgnoredRooms is an array of string. We also know that the chatroom name is a string and it exists
`if (IgnoredRooms.indexOf(ChatRoom[C].Name.toUpperCase()) == -1)`