### PR TITLE
Support array in active poses

### DIFF
--- a/app.js
+++ b/app.js
@@ -781,7 +781,8 @@ function ChatRoomCharacterExpressionUpdate(data, socket) {
 // Updates a character pose for a chat room, this does not update the database
 function ChatRoomCharacterPoseUpdate(data, socket) {
 	if ((data != null) && (typeof data === "object")) {
-		if (typeof data.Pose !== "string") data.Pose = null;
+		if (typeof data.Pose !== "string" && !Array.isArray(data.Pose)) data.Pose = null;
+		if (Array.isArray(data.Pose)) data.Pose = data.Pose.filter(P => typeof P === "string");
 		var Acc = AccountGet(socket.id);
 		if (Acc != null) Acc.ActivePose = data.Pose;
 		for (var A = 0; (Acc != null) && (Acc.ChatRoom != null) && (Acc.ChatRoom.Account != null) && (A < Acc.ChatRoom.Account.length); A++)


### PR DESCRIPTION
**This PR goes with [#1336](https://github.com/Ben987/Bondage-College/pull/1336)**

Allow the Active pose data to be an array.

This will no conflict with the live version, and will work with beta. Note that non-beta users will just see characters standing when the active pose is an array, but it does not create any bugs or crashes