### PR TITLE
Check ChatRoomGetAllowItem for Leash beeps

### DIFF
--- a/app.js
+++ b/app.js
@@ -457,7 +457,7 @@ function AccountBeep(data, socket) {
 		if (Acc != null)
 			for (var A = 0; A < Account.length; A++)
 				if (Account[A].MemberNumber == data.MemberNumber)
-					if ((Account[A].Environment == Acc.Environment) && (((Account[A].FriendList != null) && (Account[A].FriendList.indexOf(Acc.MemberNumber) >= 0)) || ((Account[A].Ownership != null) && (Account[A].Ownership.MemberNumber != null) && (Account[A].Ownership.MemberNumber == Acc.MemberNumber)) || ((data.BeepType != null) && (typeof data.BeepType === "string") && (data.BeepType == "Leash"))))
+					if ((Account[A].Environment == Acc.Environment) && (((Account[A].FriendList != null) && (Account[A].FriendList.indexOf(Acc.MemberNumber) >= 0)) || ((Account[A].Ownership != null) && (Account[A].Ownership.MemberNumber != null) && (Account[A].Ownership.MemberNumber == Acc.MemberNumber)) || ((data.BeepType === "Leash") && ChatRoomGetAllowItem(Acc, Account[A]))))
 						Account[A].Socket.emit("AccountBeep", { MemberNumber: Acc.MemberNumber, MemberName: Acc.Name, ChatRoomSpace: (Acc.ChatRoom == null) ? null : Acc.ChatRoom.Space, ChatRoomName: (Acc.ChatRoom == null) ? null : Acc.ChatRoom.Name, BeepType: (data.BeepType) ? data.BeepType : null });
 
 	}


### PR DESCRIPTION
Currently the only checks for allowing someone to pull a member using their leash is done on the leash holders client which means that for example a blacklisted player could pull someone into a room either by having grabbed the leash before being blacklisted or using console commands. The leashed player's client just checks if the beep is from their current leash holder.

Easiest way to reproduce is to grab a leash with a character and then change the leashed character's permissions to not allow the holder to interact with her and have the holder move to another room.

Adds a `ChatRoomGetAllowItem` check for `Leash` beeps, partially bringing it in line with how the interface works. I've tested it with most combinations of friends, white- and blacklisting, lovers and owners but I can't say for sure if I've hit them all.
Also simplifies the `Leash` beep type check a bit.

I'd just call this a partial fix though since it still allows friends to get past the player's permissions but this at least fixes the main source of possible trolling. I have another branch which changes it to always check permissions for the `Leash` beep type but it's much more invasive and I haven't had time to test it so I'm not submitting a PR for it but [it's here if you want to take a look](https://github.com/wultir/Bondage-Club-Server/tree/leash-beep-item-permissions-2).