### PR TITLE
Fix: Check item permissions for leash beeps

### DIFF
--- a/app.js
+++ b/app.js
@@ -457,7 +457,7 @@ function AccountBeep(data, socket) {
 		if (Acc != null)
 			for (var A = 0; A < Account.length; A++)
 				if (Account[A].MemberNumber == data.MemberNumber)
-					if ((Account[A].Environment == Acc.Environment) && (((Account[A].FriendList != null) && (Account[A].FriendList.indexOf(Acc.MemberNumber) >= 0)) || ((Account[A].Ownership != null) && (Account[A].Ownership.MemberNumber != null) && (Account[A].Ownership.MemberNumber == Acc.MemberNumber)) || ((data.BeepType != null) && (typeof data.BeepType === "string") && (data.BeepType == "Leash"))))
+					if ((Account[A].Environment == Acc.Environment) && (((Account[A].FriendList != null) && (Account[A].FriendList.indexOf(Acc.MemberNumber) >= 0)) || ((Account[A].Ownership != null) && (Account[A].Ownership.MemberNumber != null) && (Account[A].Ownership.MemberNumber == Acc.MemberNumber)) || ((data.BeepType === "Leash") && ChatRoomGetAllowItem(Acc, Account[A]))))
 						Account[A].Socket.emit("AccountBeep", { MemberNumber: Acc.MemberNumber, MemberName: Acc.Name, ChatRoomSpace: (Acc.ChatRoom == null) ? null : Acc.ChatRoom.Space, ChatRoomName: (Acc.ChatRoom == null) ? null : Acc.ChatRoom.Name, BeepType: (data.BeepType) ? data.BeepType : null });
 
 	}

--- a/app.js
+++ b/app.js
@@ -457,7 +457,7 @@ function AccountBeep(data, socket) {
 		if (Acc != null)
 			for (var A = 0; A < Account.length; A++)
 				if (Account[A].MemberNumber == data.MemberNumber)
-					if ((Account[A].Environment == Acc.Environment) && AccountBeepIsAllowed(Acc, Account[A], data.BeepType))
+					if (AccountBeepIsAllowed(Acc, Account[A], data.BeepType))
 						Account[A].Socket.emit("AccountBeep", { MemberNumber: Acc.MemberNumber, MemberName: Acc.Name, ChatRoomSpace: (Acc.ChatRoom == null) ? null : Acc.ChatRoom.Space, ChatRoomName: (Acc.ChatRoom == null) ? null : Acc.ChatRoom.Name, BeepType: (data.BeepType) ? data.BeepType : null });
 
 	}
@@ -485,7 +485,13 @@ function AccountGet(ID) {
 
 // Returns TRUE if the source is allowed to beep the target
 function AccountBeepIsAllowed(source, target, beepType) {
+	// Accounts must be in same environment
+	if (target.Environment != source.Environment) return false;
+
+	// Leash beeps require item permissions
 	if (beepType === "Leash") return ChatRoomGetAllowItem(source, target);
+
+	// Other beeps can be performed by friends or owner
 	return AccountIsInFriendList(source, target) || AccountIsOwner(source, target);
 }
 

--- a/app.js
+++ b/app.js
@@ -457,7 +457,7 @@ function AccountBeep(data, socket) {
 		if (Acc != null)
 			for (var A = 0; A < Account.length; A++)
 				if (Account[A].MemberNumber == data.MemberNumber)
-					if ((Account[A].Environment == Acc.Environment) && (((Account[A].FriendList != null) && (Account[A].FriendList.indexOf(Acc.MemberNumber) >= 0)) || ((Account[A].Ownership != null) && (Account[A].Ownership.MemberNumber != null) && (Account[A].Ownership.MemberNumber == Acc.MemberNumber)) || ((data.BeepType === "Leash") && ChatRoomGetAllowItem(Acc, Account[A]))))
+					if ((Account[A].Environment == Acc.Environment) && AccountBeepIsAllowed(Acc, Account[A], data.BeepType))
 						Account[A].Socket.emit("AccountBeep", { MemberNumber: Acc.MemberNumber, MemberName: Acc.Name, ChatRoomSpace: (Acc.ChatRoom == null) ? null : Acc.ChatRoom.Space, ChatRoomName: (Acc.ChatRoom == null) ? null : Acc.ChatRoom.Name, BeepType: (data.BeepType) ? data.BeepType : null });
 
 	}
@@ -481,6 +481,23 @@ function AccountGet(ID) {
 		if (Account[P].ID == ID)
 			return Account[P];
 	return null;
+}
+
+// Returns TRUE if the source is allowed to beep the target
+function AccountBeepIsAllowed(source, target, beepType) {
+	if (beepType === "Leash") return ChatRoomGetAllowItem(source, target);
+	return AccountIsInFriendList(source, target) || AccountIsOwner(source, target);
+}
+
+// Returns TRUE if source account is in target account's friend list
+function AccountIsInFriendList(source, target) {
+	return (target.FriendList != null) && (target.FriendList.indexOf(source.MemberNumber) >= 0)
+}
+
+// Returns TRUE if source account is target account's owner
+function AccountIsOwner(source, target) {
+	const ownership = target.Ownership;
+	return (ownership != null) && (ownership.MemberNumber != null) && (ownership.MemberNumber == source.MemberNumber);
 }
 
 // When a user searches for a chat room


### PR DESCRIPTION
Except for checking lover/owner lock and leash blocking (tethered, enclose etc) there is currently no check  except on the leash holder's client if a leash beep is allowed which means that a player who isn't allowed to use items on the leashed player can still pull them to another room using the console.

This PR does the following:
- Creates utility functions for checking if beeping is allowed, if a player is in another player's friend list and if a player is another player's owner to make the actual fixes much easier to follow. These utility functions are currently only used in the beep checking to keep server changes to a minimum but can of course be used elsewhere.
- Changes the `Leash` beep type to require item permissions, bringing it in line with the client side checking for leashing.
- Keeps beep permissions the same for regular beeps

I've tested regular beeps from friends/owner/lover/other users and they work the same as previously.
I believe I've tested all combinations of permissions and player types for leash beeps but there is always the chance that I've missed some.
More testing is of course needed, especially since it's a server change.