### PR TITLE
Bugfix: Allows players to break with non-existent lovers

### DIFF
--- a/app.js
+++ b/app.js
@@ -1295,11 +1295,11 @@ function AccountLovership(data, socket) {
 
 						AccountUpdateLovership(P, data.MemberNumber, null,false);
 
-						// Updates the account that triggered the break up
-						if (Array.isArray(Acc.Lovership)) Acc.Lovership.splice(AL, 1);
-						else Acc.Lovership = [];
-						AccountUpdateLovership(Acc.Lovership, Acc.MemberNumber);
 					}
+					// Updates the account that triggered the break up
+					if (Array.isArray(Acc.Lovership)) Acc.Lovership.splice(AL, 1);
+					else Acc.Lovership = [];
+					AccountUpdateLovership(Acc.Lovership, Acc.MemberNumber);
 				});
 				return;
 			}


### PR DESCRIPTION
## Summary

As a result of recent account purges, some players have been left with lovers whose accounts no longer exist. It is currently not possible to break with those lovers properly, as the player's database account update only currently happens if their lover's account can be found. This Fixes that so that a player's account is now updated even if their lover cannot be found in the database.