### PR TITLE
Fix: ErrorDuplicatedLogin removing two accounts

### DIFF
--- a/app.js
+++ b/app.js
@@ -292,13 +292,15 @@ function AccountLogin(data, socket) {
 					if (res) {
 
 						// Disconnect duplicated logged accounts
-						for (var A = 0; A < Account.length; A++)
-							if (Account[A].AccountName == result.AccountName) {
-								Account[A].Socket.emit("ForceDisconnect", "ErrorDuplicatedLogin");
-								Account[A].Socket.disconnect(true);
-								if (Account[A] != null) AccountRemove(Account[A].ID);
+						for (let A = 0; A < Account.length; A++) {
+							const Acc = Account[A];
+							if (Acc.AccountName === result.AccountName) {
+								Acc.Socket.emit("ForceDisconnect", "ErrorDuplicatedLogin");
+								Acc.Socket.disconnect(true);
+								AccountRemove(Acc.ID);
 								break;
 							}
+						}
 
 						// Assigns a member number if there's none
 						if (result.MemberNumber == null) {


### PR DESCRIPTION
Finally found the source of `AccountError` problems that started happening recently.

The problem was, that during removal of duplicated account two different accounts were accidentally getting removed.

Bug reproduced reliably without the fix and the fix has been tested.