### PR TITLE
Added tamper evidence system

### DIFF
--- a/app.js
+++ b/app.js
@@ -409,6 +409,20 @@ function AccountUpdate(data, socket) {
 				}
 				if ((data.Title != null)) Account[P].Title = data.Title;
 
+				// Validate TamperLock, removing any group from TamperLock that isn't represented in Appearance
+				if (Account[P].TamperLock && data.Appearance) {
+					var TamperLocksTemp = {}
+					for (var A in Account[P].TamperLock) {
+						if (Account[P].TamperLock[A] && data.Appearance.some(elem => ((A == elem.Group)
+															&& (elem.Property && Account[P].TamperLock[A].LockType == elem.Property.LockedBy)))) {
+																TamperLocksTemp[A] = Account[P].TamperLock[A]
+															}
+					}
+				
+					Account[P].TamperLock = TamperLocksTemp
+					data.TamperLock = TamperLocksTemp
+				}
+
 				// If we have data to push
 				if (!ObjectEmpty(data)) Database.collection("Accounts").updateOne({ AccountName : Account[P].AccountName }, { $set: data }, function(err, res) { if (err) throw err; });
 				break;

--- a/app.js
+++ b/app.js
@@ -1527,7 +1527,7 @@ function AccountTamperLock(data, socket) {
 			if (Target.Appearance.some(elem => data.Group === elem.Group)) {
 				// Updates the account and the database
 				var NewTampering = (Target.TamperLock) ? {TamperLock: Target.TamperLock} : {TamperLock: {}};
-				NewTampering.TamperLock[data.Group] = { LastChange: CommonTime(), AppliedBy: Acc.MemberNumber, AppliedByName: Acc.AccountName, LockType: data.LockType }
+				NewTampering.TamperLock[data.Group] = { LastChange: CommonTime(), AppliedBy: Acc.MemberNumber, AppliedByName: Acc.Name, LockType: data.LockType }
 				Target.TamperLock = NewTampering.TamperLock
 				//console.log("Updating account " + Target.AccountName + " tampering to " + NewTampering + " by " + Acc.AccountName);
 				Database.collection("Accounts").updateOne({ AccountName : Target.AccountName }, { $set: NewTampering }, function(err, res) { if (err) throw err; });


### PR DESCRIPTION
Adds a tamper-evidence system which works in the following way:
-Accounts have a dictionary called TamperLock which stores information on which groups were last modified with a tamper-proof lock.
-When an account that has access to the player sends a tamperlock message, the server attaches the current time and name/membernumber of the person who sent the tamperlock message, and appends it to the current list
-If successful, it sends the tamper list to all players in the chatroom so that it updates on their screen
-both players must be in the same chatroom and the person applying must have permission on the target
-Values are synced on login and in character loading in chatrooms



There is one vulnerability, which is that someone can maliciously send TamperMessages to a player to reset the time on their tamper proof locks. However, the variable also stores the name and member number of whomever sent the update, so it will be clear to the owner (or whomever put the lock on there) that someone else tampered with the lock.

This system does not reapply locks, it only provides accounts with a record of when the lock was placed and by whom.