### PR TITLE
ChatRoomSync Split

### DIFF
--- a/app.js
+++ b/app.js
@@ -919,7 +919,6 @@ function ChatRoomSyncCharacter(CR, SourceMemberNumber, TargetMemberNumber) {
 function ChatRoomSyncMemberJoin(CR, SourceMemberNumber) {
 	// Exits right away if the chat room was destroyed
 	if (CR == null) return;
-	console.log("ChatRoomSyncMemberJoin")
 	let joinData = { }
 	joinData.SourceMemberNumber = SourceMemberNumber
 	joinData.Character = null
@@ -1262,12 +1261,12 @@ function ChatRoomAdmin(data, socket) {
 					if (data.Action == "Ban") {
 						Acc.ChatRoom.Ban.push(data.MemberNumber);
 						Acc.ChatRoom.Account[A].Socket.emit("ChatRoomSearchResponse", "RoomBanned");
-						ChatRoomSyncRoomProperties(Acc.ChatRoom, Acc.MemberNumber);
 						if ((Acc != null) && (Acc.ChatRoom != null) && (Acc.ChatRoom.Account[A] != null)) {
 							Dictionary.push({Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber});
 							Dictionary.push({Tag: "TargetCharacterName", Text: Acc.ChatRoom.Account[A].Name, MemberNumber: Acc.ChatRoom.Account[A].MemberNumber});
 							ChatRoomRemove(Acc.ChatRoom.Account[A], "ServerBan", Dictionary);
 						}
+						ChatRoomSyncRoomProperties(Acc.ChatRoom, Acc.MemberNumber);
 					}
 					else if (data.Action == "Kick") {
 						Acc.ChatRoom.Account[A].Socket.emit("ChatRoomSearchResponse", "RoomKicked");

--- a/app.js
+++ b/app.js
@@ -1262,6 +1262,7 @@ function ChatRoomAdmin(data, socket) {
 					if (data.Action == "Ban") {
 						Acc.ChatRoom.Ban.push(data.MemberNumber);
 						Acc.ChatRoom.Account[A].Socket.emit("ChatRoomSearchResponse", "RoomBanned");
+						ChatRoomSyncRoomProperties(Acc.ChatRoom, Acc.MemberNumber);
 						if ((Acc != null) && (Acc.ChatRoom != null) && (Acc.ChatRoom.Account[A] != null)) {
 							Dictionary.push({Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber});
 							Dictionary.push({Tag: "TargetCharacterName", Text: Acc.ChatRoom.Account[A].Name, MemberNumber: Acc.ChatRoom.Account[A].MemberNumber});
@@ -1322,8 +1323,16 @@ function ChatRoomAdmin(data, socket) {
 				}
 
 			// Can also ban or unban without having the player in the room, there's no visible output
-			if ((data.Action == "Ban") && (Acc.ChatRoom.Ban.indexOf(data.MemberNumber) < 0)) Acc.ChatRoom.Ban.push(data.MemberNumber);
-			if ((data.Action == "Unban") && (Acc.ChatRoom.Ban.indexOf(data.MemberNumber) >= 0)) Acc.ChatRoom.Ban.splice(Acc.ChatRoom.Ban.indexOf(data.MemberNumber), 1);
+			if ((data.Action == "Ban") && (Acc.ChatRoom.Ban.indexOf(data.MemberNumber) < 0))
+			{
+				Acc.ChatRoom.Ban.push(data.MemberNumber);
+				ChatRoomSyncRoomProperties(Acc.ChatRoom, Acc.MemberNumber);
+			}
+			if ((data.Action == "Unban") && (Acc.ChatRoom.Ban.indexOf(data.MemberNumber) >= 0))
+			{
+				Acc.ChatRoom.Ban.splice(Acc.ChatRoom.Ban.indexOf(data.MemberNumber), 1);
+				ChatRoomSyncRoomProperties(Acc.ChatRoom, Acc.MemberNumber);
+			}
 		}
 
 	}


### PR DESCRIPTION
**This is the related server PR to Client PR [#2253](https://github.com/Ben987/Bondage-College/pull/2253)**

As in the client PR description mentioned, this Splits the ChatRoomSync function into multiple smaller calls which each transfers only the required data. It was not avoidable to add temporary code to check if a player uses the old game version (R66) or a new one. Depending on this, either the new ChatRoomSync alternative is called for beta players or the old ChatRoomSync for R66 players.

I'll remove this temporary code again once the beta is over and all players are using the new communication.

As also mentioned in the client PR, thorough testing is a necessity for big ones like this. And even though i'm sure there are no critical bugs, i want to encourage repeated tests during the review, just to be safe.