### PR TITLE
ChatRoomSync-Split: Replacement functions only

### DIFF
--- a/app.js
+++ b/app.js
@@ -928,6 +928,271 @@ function ChatRoomSync(CR, SourceMemberNumber) {
 		CR.Account[A].Socket.emit("ChatRoomSync", R);
 }
 
+
+// Syncs the room data with all of it's members
+function ChatRoomSyncToMember(CR, SourceMemberNumber, TargetMemberNumber) {
+	// Exits right away if the chat room was destroyed
+	if (CR == null) { return; }
+	
+	// Builds the room data
+	let roomData = {};
+	roomData.Name = CR.Name;
+	roomData.Description = CR.Description;
+	roomData.Admin = CR.Admin;
+	roomData.Ban = CR.Ban;
+	roomData.Background = CR.Background;
+	roomData.Limit = CR.Limit;
+	roomData.Game = CR.Game;
+	roomData.SourceMemberNumber = SourceMemberNumber;
+	roomData.Locked = CR.Locked;
+	roomData.Private = CR.Private;
+	roomData.BlockCategory = CR.BlockCategory;
+
+	// Adds the characters from the room
+	roomData.Character = [];
+	for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+	{
+		//Push character to room data
+		roomData.Character.push(ChatRoomSyncGetCharSharedData(CR.Account[i]));
+	}
+
+	// Sends the full packet to everyone in the room
+	for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+	{
+		if(CR.Account[i].MemberNumber == TargetMemberNumber) // If the player is the one who gets synced...
+		{
+			// Send room data and break loop
+			CR.Account[i].Socket.emit("ChatRoomSync", roomData);
+			break;
+		}
+	}
+}
+
+// Syncs the room data with all of it's members
+function ChatRoomSyncCharacter(CR, SourceMemberNumber, TargetMemberNumber) {
+	// Exits right away if the chat room was destroyed
+	if (CR == null) return;
+
+	let characterData = { }
+	characterData.SourceMemberNumber = SourceMemberNumber
+	characterData.Character = null
+
+	// Adds the characters from the room
+	for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+	{
+		if(CR.Account[i].MemberNumber === TargetMemberNumber) // If the player is the one we want to update...
+		{
+			//Remember character and break loop
+			characterData.Character = ChatRoomSyncGetCharSharedData(CR.Account[i])
+			break;
+		}
+	}
+
+	// Sends the full packet to everyone in the room
+	if(characterData.Character != null) // If we found a character...
+	{
+		for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+		{
+			//Todo: Remove this if-clause after "R67"
+			if(CR.Account[i].OnlineSharedSettings.GameVersion == "R66") // If this client does not support the ChatRoomSync split...
+			{
+				//Send full sync to this member for compatibility
+				ChatRoomSyncToMember(CR, SourceMemberNumber, CR.Account[i].MemberNumber)
+			}
+			else if(CR.Account[i].MemberNumber != SourceMemberNumber) // If this client supports the ChatRoomSync split and is not the character that just joined...
+			{
+				// Inform about joined player
+				CR.Account[i].Socket.emit("ChatRoomSyncCharacter", characterData);
+			}
+		}
+	}
+}
+
+// Sends the newly joined player to all chat room members
+function ChatRoomSyncMemberJoin(CR, SourceMemberNumber) {
+	// Exits right away if the chat room was destroyed
+	if (CR == null) return;
+	let joinData = { }
+	joinData.SourceMemberNumber = SourceMemberNumber
+	joinData.Character = null
+
+	// Adds the characters from the room
+	for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+	{
+		if(CR.Account[i].MemberNumber == SourceMemberNumber) // If the player is the one who just joined...
+		{
+			//Remember character and break loop
+			joinData.Character = ChatRoomSyncGetCharSharedData(CR.Account[i])
+			break;
+		}
+	}
+
+	// Sends the full packet to everyone in the room
+	if(joinData.Character != null) // If we found a character...
+	{
+		for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+		{
+			//Todo: Remove this if-clause after "R67"
+			if(CR.Account[i].OnlineSharedSettings.GameVersion == "R66") // If this client does not support the ChatRoomSync split...
+			{
+				//Send full sync to this member for compatibility
+				ChatRoomSyncToMember(CR, SourceMemberNumber, CR.Account[i].MemberNumber)
+			}
+			else if(CR.Account[i].MemberNumber != SourceMemberNumber) // If this client supports the ChatRoomSync split and is not the character that just joined...
+			{
+				// Inform about joined player
+				CR.Account[i].Socket.emit("ChatRoomSyncMemberJoin", joinData);
+			}
+		}
+	}
+	
+}
+
+// Sends the left player to all chat room members
+function ChatRoomSyncMemberLeave(CR, SourceMemberNumber) {
+	// Exits right away if the chat room was destroyed
+	if (CR == null) return;
+
+	let leaveData = { }
+	leaveData.SourceMemberNumber = SourceMemberNumber;
+
+	// Sends the full packet to everyone in the room
+	for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+	{
+		//Todo: Remove this if-clause after "R67"
+		if(CR.Account[i].OnlineSharedSettings.GameVersion == "R66") // If this client does not support the ChatRoomSync split...
+		{
+			//Send full sync to this member for compatibility
+			ChatRoomSyncToMember(CR, SourceMemberNumber, CR.Account[i].MemberNumber)
+		}
+		else // If this client supports the ChatRoomSync split...
+		{
+			// Inform about left player
+			CR.Account[i].Socket.emit("ChatRoomSyncMemberLeave", leaveData);
+		}
+	}
+	
+}
+
+// Syncs the room data with all of it's members
+function ChatRoomSyncRoomProperties(CR, SourceMemberNumber) {
+	// Exits right away if the chat room was destroyed
+	if (CR == null) return;
+
+	// Builds the room data
+	let roomData = {};
+	roomData.Name = CR.Name;
+	roomData.Description = CR.Description;
+	roomData.Admin = CR.Admin;
+	roomData.Ban = CR.Ban;
+	roomData.Background = CR.Background;
+	roomData.Limit = CR.Limit;
+	roomData.Game = CR.Game;
+	roomData.SourceMemberNumber = SourceMemberNumber;
+	roomData.Locked = CR.Locked;
+	roomData.Private = CR.Private;
+	roomData.BlockCategory = CR.BlockCategory;
+
+	// Sends the full packet to everyone in the room
+	for (var i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+	{
+		//Todo: Remove this if-clause after "R67"
+		if(CR.Account[i].OnlineSharedSettings.GameVersion == "R66") // If this client does not support the ChatRoomSync split...
+		{
+			//Send full sync to this member for compatibility
+			ChatRoomSyncToMember(CR, SourceMemberNumber, CR.Account[i].MemberNumber)
+		}
+		else // If this client supports the ChatRoomSync split...
+		{
+			// Send new room properties to player
+			CR.Account[i].Socket.emit("ChatRoomSyncRoomProperties", roomData);
+		}
+	}
+}
+
+// Syncs the room data with all of it's members
+function ChatRoomSyncSwapPlayers(CR, SourceMemberNumber, MemberNumber1, MemberNumber2) {
+	// Exits right away if the chat room was destroyed
+	if (CR == null) return;
+
+	// Builds the room data
+	let swapData = {};
+
+	swapData.MemberNumber1 = MemberNumber1
+	swapData.MemberNumber2 = MemberNumber2
+
+	// Sends the full packet to everyone in the room
+	for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+	{
+		//Todo: Remove this if-clause after "R67"
+		if(CR.Account[i].OnlineSharedSettings.GameVersion == "R66") // If this client does not support the ChatRoomSync split...
+		{
+			//Send full sync to this member for compatibility
+			ChatRoomSyncToMember(CR, SourceMemberNumber, CR.Account[i].MemberNumber)
+		}
+		else // If this client supports the ChatRoomSync split...
+		{
+			// Inform players about swap
+			CR.Account[i].Socket.emit("ChatRoomSyncSwapPlayers", swapData);
+		}
+	}
+}
+
+// Syncs the room data with all of it's members
+function ChatRoomSyncMovePlayer(CR, SourceMemberNumber, TargetMemberNumber, Direction) {
+	// Exits right away if the chat room was destroyed
+	if (CR == null) return;
+
+	// Builds the room data
+	let moveData = {};
+
+	moveData.TargetMemberNumber = TargetMemberNumber
+	moveData.Direction = Direction
+
+	// Sends the full packet to everyone in the room
+	for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+	{
+		//Todo: Remove this if-clause after "R67"
+		if(CR.Account[i].OnlineSharedSettings.GameVersion == "R66") // If this client does not support the ChatRoomSync split...
+		{
+			//Send full sync to this member for compatibility
+			ChatRoomSyncToMember(CR, SourceMemberNumber, CR.Account[i].MemberNumber)
+		}
+		else // If this client supports the ChatRoomSync split...
+		{
+			// Inform players about move
+			CR.Account[i].Socket.emit("ChatRoomSyncMovePlayer", moveData);
+		}
+	}
+}
+
+// Syncs the room data with all of it's members
+function ChatRoomSyncReorderPlayers(CR, SourceMemberNumber, NewPlayerOrder) {
+	// Exits right away if the chat room was destroyed
+	if (CR == null) return;
+
+	// Builds the room data
+	let reorderData = {};
+
+	reorderData.PlayerOrder = NewPlayerOrder
+
+	// Sends the full packet to everyone in the room
+	for (let i = 0; i < CR.Account.length; i++) // For each player in the chat room...
+	{
+		//Todo: Remove this if-clause after "R67"
+		if(CR.Account[i].OnlineSharedSettings.GameVersion == "R66") // If this client does not support the ChatRoomSync split...
+		{
+			//Send full sync to this member for compatibility
+			ChatRoomSyncToMember(CR, SourceMemberNumber, CR.Account[i].MemberNumber)
+		}
+		else // If this client supports the ChatRoomSync split...
+		{
+			// Inform players about move
+			CR.Account[i].Socket.emit("ChatRoomSyncReorderPlayers", reorderData);
+		}
+	}
+}
+
 // Syncs a single character data with all room members
 function ChatRoomSyncSingle(Acc, SourceMemberNumber) {
 	var R = {};


### PR DESCRIPTION
Even though this PR includes all the functions introduced in #76, it does not enable them for usage yet. For this purpose, seperate pull requests will be opened. This is to make testing the individual functions easier as requested by @Ben987.
The same has been done with the related Client PR [#2253](https://github.com/Ben987/Bondage-College/pull/2253), which got split as described in [#2272](https://github.com/Ben987/Bondage-College/pull/2272).

**As this is the major part of the split of #76 in smaller PRs, i'll duplicate it's description here to make it easier to keep an overview over the total functionality**

> **This is the related server PR to Client PR [#2253](https://github.com/Ben987/Bondage-College/pull/2253)**
> 
> As in the client PR description mentioned, this Splits the ChatRoomSync function into multiple smaller calls which each transfers only the required data. It was not avoidable to add temporary code to check if a player uses the old game version (R66) or a new one. Depending on this, either the new ChatRoomSync alternative is called for beta players or the old ChatRoomSync for R66 players.
> 
> I'll remove this temporary code again once the beta is over and all players are using the new communication.
> 
> As also mentioned in the client PR, thorough testing is a necessity for big ones like this. And even though i'm sure there are no critical bugs, i want to encourage repeated tests during the review, just to be safe.