### PR TITLE
ChatRoomSync-Split: Enable ChatRoomSyncMovePlayer

### DIFF
--- a/app.js
+++ b/app.js
@@ -1276,7 +1276,7 @@ function ChatRoomAdmin(data, socket) {
 						Dictionary.push({Tag: "TargetCharacterName", Text: MovedAccount.Name, MemberNumber: MovedAccount.MemberNumber});
 						Dictionary.push({Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber});
 						if ((data.Publish != null) && (typeof data.Publish === "boolean") && data.Publish) ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "ServerMoveLeft", "Action", null, Dictionary);
-						ChatRoomSync(Acc.ChatRoom, Acc.MemberNumber);
+						ChatRoomSyncMovePlayer(Acc.ChatRoom, Acc.MemberNumber, MovedAccount.MemberNumber, "Left");
 					}
 					else if ((data.Action == "MoveRight") && (A < Acc.ChatRoom.Account.length - 1)) {
 						var MovedAccount = Acc.ChatRoom.Account[A];
@@ -1285,7 +1285,7 @@ function ChatRoomAdmin(data, socket) {
 						Dictionary.push({Tag: "TargetCharacterName", Text: MovedAccount.Name, MemberNumber: MovedAccount.MemberNumber});
 						Dictionary.push({Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber});
 						if ((data.Publish != null) && (typeof data.Publish === "boolean") && data.Publish) ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "ServerMoveRight", "Action", null, Dictionary);
-						ChatRoomSync(Acc.ChatRoom, Acc.MemberNumber);
+						ChatRoomSyncMovePlayer(Acc.ChatRoom, Acc.MemberNumber, MovedAccount.MemberNumber, "Right");
 					}
 					else if (data.Action == "Shuffle") {
 						for (var X = 0; X < Acc.ChatRoom.Account.length; X++)

--- a/app.js
+++ b/app.js
@@ -1062,22 +1062,6 @@ function ChatRoomSyncSwapPlayers(CR, SourceMemberNumber, MemberNumber1, MemberNu
 }
 
 // Syncs the room data with all of it's members
-function ChatRoomSyncMovePlayer(CR, SourceMemberNumber, TargetMemberNumber, Direction) {
-	// Exits right away if the chat room was destroyed
-	if (CR == null) return;
-
-	// Builds the room data
-	let moveData = {};
-
-	moveData.TargetMemberNumber = TargetMemberNumber
-	moveData.Direction = Direction
-
-	// Sends the full packet to everyone in the room
-	if (!ChatRoomSyncToOldClients(CR, SourceMemberNumber))
-		IO.to("chatroom-" + CR.ID).emit("ChatRoomSyncMovePlayer", moveData);
-}
-
-// Syncs the room data with all of it's members
 function ChatRoomSyncReorderPlayers(CR, SourceMemberNumber, NewPlayerOrder) {
 	// Exits right away if the chat room was destroyed
 	if (CR == null) return;
@@ -1270,22 +1254,30 @@ function ChatRoomAdmin(data, socket) {
 						}
 					}
 					else if ((data.Action == "MoveLeft") && (A != 0)) {
-						var MovedAccount = Acc.ChatRoom.Account[A];
+						let MovedAccount = Acc.ChatRoom.Account[A];
 						Acc.ChatRoom.Account[A] = Acc.ChatRoom.Account[A - 1];
 						Acc.ChatRoom.Account[A - 1] = MovedAccount;
+						let newPlayerOrder = [];
+						for (let i = 0; i < Acc.ChatRoom.Account.length; i++) {
+							newPlayerOrder.push(Acc.ChatRoom.Account[i].MemberNumber);
+						}
 						Dictionary.push({Tag: "TargetCharacterName", Text: MovedAccount.Name, MemberNumber: MovedAccount.MemberNumber});
 						Dictionary.push({Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber});
 						if ((data.Publish != null) && (typeof data.Publish === "boolean") && data.Publish) ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "ServerMoveLeft", "Action", null, Dictionary);
-						ChatRoomSyncMovePlayer(Acc.ChatRoom, Acc.MemberNumber, MovedAccount.MemberNumber, "Left");
+						ChatRoomSyncReorderPlayers(Acc.ChatRoom, Acc.MemberNumber, newPlayerOrder);
 					}
 					else if ((data.Action == "MoveRight") && (A < Acc.ChatRoom.Account.length - 1)) {
-						var MovedAccount = Acc.ChatRoom.Account[A];
+						let MovedAccount = Acc.ChatRoom.Account[A];
 						Acc.ChatRoom.Account[A] = Acc.ChatRoom.Account[A + 1];
 						Acc.ChatRoom.Account[A + 1] = MovedAccount;
+						let newPlayerOrder = [];
+						for (let i = 0; i < Acc.ChatRoom.Account.length; i++) {
+							newPlayerOrder.push(Acc.ChatRoom.Account[i].MemberNumber);
+						}
 						Dictionary.push({Tag: "TargetCharacterName", Text: MovedAccount.Name, MemberNumber: MovedAccount.MemberNumber});
 						Dictionary.push({Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber});
 						if ((data.Publish != null) && (typeof data.Publish === "boolean") && data.Publish) ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "ServerMoveRight", "Action", null, Dictionary);
-						ChatRoomSyncMovePlayer(Acc.ChatRoom, Acc.MemberNumber, MovedAccount.MemberNumber, "Right");
+						ChatRoomSyncReorderPlayers(Acc.ChatRoom, Acc.MemberNumber, newPlayerOrder);
 					}
 					else if (data.Action == "Shuffle") {
 						for (var X = 0; X < Acc.ChatRoom.Account.length; X++)

--- a/app.js
+++ b/app.js
@@ -971,7 +971,7 @@ function ChatRoomSyncToMember(CR, SourceMemberNumber, TargetMemberNumber) {
 function ChatRoomSyncToOldClients(CR, SourceMemberNumber, Source) {
 	if (CR == null) { return; }
 
-	if (CR.Account.some(C => C.OnlineSharedSettings?.GameVersion == "R66")) {
+	if (CR.Account.some(C => C.OnlineSharedSettings?.GameVersion == "R67")) {
 		const roomData = ChatRoomGetData(CR, SourceMemberNumber, true);
 		if (Source) Source.Socket.to("chatroom-" + CR.ID).emit("ChatRoomSync", roomData);
 		else IO.to("chatroom-" + CR.ID).emit("ChatRoomSync", roomData);
@@ -1020,9 +1020,7 @@ function ChatRoomSyncMemberJoin(CR, Character) {
 	}
 
 	Character.Socket.to("chatroom-" + CR.ID).emit("ChatRoomSyncMemberJoin", joinData);
-
-	if (!ChatRoomSyncToOldClients(CR, Character.MemberNumber))
-		ChatRoomSyncToMember(CR, Character.MemberNumber, Character.MemberNumber);
+	ChatRoomSyncToMember(CR, Character.MemberNumber, Character.MemberNumber);
 }
 
 // Sends the left player to all chat room members
@@ -1034,8 +1032,7 @@ function ChatRoomSyncMemberLeave(CR, SourceMemberNumber) {
 	leaveData.SourceMemberNumber = SourceMemberNumber;
 
 	// Sends the full packet to everyone in the room
-	if (!ChatRoomSyncToOldClients(CR, SourceMemberNumber))
-		IO.to("chatroom-" + CR.ID).emit("ChatRoomSyncMemberLeave", leaveData);
+	IO.to("chatroom-" + CR.ID).emit("ChatRoomSyncMemberLeave", leaveData);
 }
 
 // Syncs the room data with all of it's members


### PR DESCRIPTION
**Depends on: #89** 

This PR enables the use of function `ChatRoomSyncMovePlayer` added by PR #79 on which it depends. It is required by Client PR [#2278](https://github.com/Ben987/Bondage-College/pull/2278).

**Edit:**
`ChatRoomSyncMovePlayer` has been replaced with `ChatRoomSyncReorderPlayers`. This now relates on client PR [2279](https://github.com/Ben987/Bondage-College/pull/2279)