### PR TITLE
Fix: Send WhiteList&BlackList updates on join

### DIFF
--- a/app.js
+++ b/app.js
@@ -869,6 +869,20 @@ function ChatRoomGame(data, socket) {
 
 // Builds the character packet to send over to the clients, white list is only sent if there are limited items and a low item permission
 function ChatRoomSyncGetCharSharedData(Acc) {
+	const WhiteList = [];
+	const BlackList = [];
+	// We filter whitelist&blacklist based on people in room
+	if (Acc.ChatRoom && Acc.ChatRoom.Account) {
+		for (const B of Acc.ChatRoom.Account) {
+			if (Acc.WhiteList.includes(B.MemberNumber)) {
+				WhiteList.push(B.MemberNumber);
+			}
+			if (Acc.BlackList.includes(B.MemberNumber)) {
+				BlackList.push(B.MemberNumber);
+			}
+		}
+	}
+
 	return {
 		ID: Acc.ID,
 		Name: Acc.Name,
@@ -890,8 +904,8 @@ function ChatRoomSyncGetCharSharedData(Acc) {
 		LimitedItems: Acc.LimitedItems,
 		ArousalSettings: Acc.ArousalSettings,
 		OnlineSharedSettings: Acc.OnlineSharedSettings,
-		WhiteList: Array.isArray(Acc.WhiteList) ? Acc.WhiteList : [],
-		BlackList: Array.isArray(Acc.BlackList) ? Acc.BlackList : [],
+		WhiteList,
+		BlackList,
 		Game: Acc.Game,
 		Difficulty: Acc.Difficulty
 	};
@@ -990,8 +1004,19 @@ function ChatRoomSyncMemberJoin(CR, Character) {
 	if (CR == null) return;
 	let joinData = {
 		SourceMemberNumber: Character.MemberNumber,
-		Character: ChatRoomSyncGetCharSharedData(Character)
+		Character: ChatRoomSyncGetCharSharedData(Character),
+		WhiteListedBy: [],
+		BlackListedBy: []
 	};
+
+	for (const B of CR.Account) {
+		if (B.WhiteList.includes(Character.MemberNumber)) {
+			joinData.WhiteListedBy.push(B.MemberNumber);
+		}
+		if (B.BlackList.includes(Character.MemberNumber)) {
+			joinData.BlackListedBy.push(B.MemberNumber);
+		}
+	}
 
 	Character.Socket.to("chatroom-" + CR.ID).emit("ChatRoomSyncMemberJoin", joinData);
 

--- a/app.js
+++ b/app.js
@@ -871,13 +871,14 @@ function ChatRoomGame(data, socket) {
 function ChatRoomSyncGetCharSharedData(Acc) {
 	const WhiteList = [];
 	const BlackList = [];
+	const sendBlacklist = AccountShouldSendBlackList(Acc);
 	// We filter whitelist&blacklist based on people in room
 	if (Acc.ChatRoom && Acc.ChatRoom.Account) {
 		for (const B of Acc.ChatRoom.Account) {
 			if (Acc.WhiteList.includes(B.MemberNumber)) {
 				WhiteList.push(B.MemberNumber);
 			}
-			if (Acc.BlackList.includes(B.MemberNumber)) {
+			if (sendBlacklist && Acc.BlackList.includes(B.MemberNumber)) {
 				BlackList.push(B.MemberNumber);
 			}
 		}
@@ -1013,7 +1014,7 @@ function ChatRoomSyncMemberJoin(CR, Character) {
 		if (B.WhiteList.includes(Character.MemberNumber)) {
 			joinData.WhiteListedBy.push(B.MemberNumber);
 		}
-		if (B.BlackList.includes(Character.MemberNumber)) {
+		if (AccountShouldSendBlackList(B) && B.BlackList.includes(Character.MemberNumber)) {
 			joinData.BlackListedBy.push(B.MemberNumber);
 		}
 	}
@@ -1328,6 +1329,18 @@ function ChatRoomDominantValue(Account) {
 			if ((Account.Reputation[R].Type != null) && (Account.Reputation[R].Value != null) && (typeof Account.Reputation[R].Type === "string") && (typeof Account.Reputation[R].Value === "number") && (Account.Reputation[R].Type == "Dominant"))
 				return parseInt(Account.Reputation[R].Value);
 	return 0;
+}
+
+/**
+ * Checks if account's blacklist should be sent.
+ * It should only be sent if it is easily visible a person in blacklisted without this info.
+ * This means if the player is on permission that blocks depending on blacklist
+ * @see ChatRoomGetAllowItem
+ * @param {Account} Acc The account to check
+ * @returns {boolean}
+ */
+function AccountShouldSendBlackList(Acc) {
+	return Acc.ItemPermission === 1 || Acc.ItemPermission === 2;
 }
 
 // Compares the source account and target account to check if we allow using an item

--- a/app.js
+++ b/app.js
@@ -869,41 +869,32 @@ function ChatRoomGame(data, socket) {
 
 // Builds the character packet to send over to the clients, white list is only sent if there are limited items and a low item permission
 function ChatRoomSyncGetCharSharedData(Acc) {
-	const Whitelist = [];
-	// We filter whitelist based on people in room
-	if (Array.isArray(Acc.WhiteList) && Acc.ChatRoom && Acc.ChatRoom.Account) {
-		for (const B of Acc.ChatRoom.Account) {
-			if (Acc.WhiteList.includes(B.MemberNumber)) {
-				Whitelist.push(B.MemberNumber);
-			}
-		}
-	}
-
-	const A = {};
-	A.ID = Acc.ID;
-	A.Name = Acc.Name;
-	A.AssetFamily = Acc.AssetFamily;
-	A.Title = Acc.Title;
-	A.Appearance = Acc.Appearance;
-	A.ActivePose = Acc.ActivePose;
-	A.Reputation = Acc.Reputation;
-	A.Creation = Acc.Creation;
-	A.Lovership = Acc.Lovership;
-	A.Description = Acc.Description;
-	A.Owner = Acc.Owner;
-	A.MemberNumber = Acc.MemberNumber;
-	A.LabelColor = Acc.LabelColor;
-	A.ItemPermission = Acc.ItemPermission;
-	A.Inventory = Acc.Inventory;
-	A.Ownership = Acc.Ownership;
-	A.BlockItems = Acc.BlockItems;
-	A.LimitedItems = Acc.LimitedItems;
-	A.ArousalSettings = Acc.ArousalSettings;
-	A.OnlineSharedSettings = Acc.OnlineSharedSettings;
-	A.WhiteList = Whitelist;
-	A.Game = Acc.Game;
-	A.Difficulty = Acc.Difficulty;
-	return A;
+	return {
+		ID: Acc.ID,
+		Name: Acc.Name,
+		AssetFamily: Acc.AssetFamily,
+		Title: Acc.Title,
+		Appearance: Acc.Appearance,
+		ActivePose: Acc.ActivePose,
+		Reputation: Acc.Reputation,
+		Creation: Acc.Creation,
+		Lovership: Acc.Lovership,
+		Description: Acc.Description,
+		Owner: Acc.Owner,
+		MemberNumber: Acc.MemberNumber,
+		LabelColor: Acc.LabelColor,
+		ItemPermission: Acc.ItemPermission,
+		Inventory: Acc.Inventory,
+		Ownership: Acc.Ownership,
+		BlockItems: Acc.BlockItems,
+		LimitedItems: Acc.LimitedItems,
+		ArousalSettings: Acc.ArousalSettings,
+		OnlineSharedSettings: Acc.OnlineSharedSettings,
+		WhiteList: Array.isArray(Acc.WhiteList) ? Acc.WhiteList : [],
+		BlackList: Array.isArray(Acc.BlackList) ? Acc.BlackList : [],
+		Game: Acc.Game,
+		Difficulty: Acc.Difficulty
+	};
 }
 
 // Returns a ChatRoom data that can be synced to clients


### PR DESCRIPTION
~~Changes `ChatRoomSyncGetCharSharedData` to always send full whitelist and blacklist.~~
Changes `ChatRoomSyncMemberJoin` to add newly joining player to other's *lists, if they should be there

Previously there was a change to only send whitelist for players in room as it was sent everytime anyone joined or entered.
With Tessa's change, it will only be sent when players joins or to joining player. This has two effects:
- Lot less data is sent, so there is no need to save on the whitelist as it only is sent once
- WhiteList of player already in room isn't updated when different player on whitelist joins room, this was causing a bug.

Reproduction steps for the bug (all players in room must be on new version):
Players A and B are in room - player A has player C whitelisted, but this currently isn't known to B
Player C joins, this sends correct data about A and B to C and correct data about C to A and B.
However B won't know A has C in it's whitelist
Than C uses item A has limited on her. Without being whitelisted she can't, but with it she can.
This means for A and C the item will appear on A
However B won't see this, because client will think this was invalid change for C to do

Why send BlackList?
This will allow two things to be implemented on client:
- Option to allow activities to be done on you, while you are on "whitelist only" setting, but still having blacklist block them (This was requested as part of "more dommes" talk)
- It will allow completely removing the need for `ChatRoomAllowItem` server request, which will reduce messages needed to be processed by server. This request is being send everytime someone click on character, but with BlackList available it will be possible to calculate the result without asking server at all, providing both less load for server and better experience in form of removing delay on client