### PR TITLE
Feature: Release submissive from ownership

### DIFF
--- a/app.js
+++ b/app.js
@@ -1558,9 +1558,8 @@ function AccountOwnership(data, socket) {
 					if (TargetAcc.Ownership != null &&
 						TargetAcc.Ownership.MemberNumber == Acc.MemberNumber &&
 						TargetAcc.Ownership.EndTrialOfferedByMemberNumber == null &&
-						TargetAcc.Ownership.Stage != null &&
+						TargetAcc.Ownership.Stage === 0 &&
 						TargetAcc.Ownership.Start != null &&
-						TargetAcc.Ownership.Stage == 0 &&
 						TargetAcc.Ownership.Start + OwnershipDelay <= CommonTime()
 					) {
 						if (data.Action === "Propose") {
@@ -1599,7 +1598,7 @@ function AccountOwnership(data, socket) {
 					Acc.Ownership.EndTrialOfferedByMemberNumber != null &&
 					Acc.Ownership.EndTrialOfferedByMemberNumber == data.MemberNumber
 				) {
-					if ((data.Action != null) && (typeof data.Action === "string") && (data.Action == "Accept")) {
+					if (data.Action === "Accept") {
 						Acc.Owner = TargetAcc.Name;
 						Acc.Ownership = { MemberNumber: data.MemberNumber, Name: TargetAcc.Name, Start: CommonTime(), Stage: 1 };
 						let O = { Ownership: Acc.Ownership, Owner: Acc.Owner };

--- a/app.js
+++ b/app.js
@@ -1518,33 +1518,34 @@ function AccountOwnership(data, socket) {
 			Acc.Ownership.MemberNumber != data.MemberNumber
 		) {
 			for (var A = 0; A < Acc.ChatRoom.Account.length; A++) {
-				if (Acc.ChatRoom.Account[A].MemberNumber == data.MemberNumber &&
+				const TargetAcc = Acc.ChatRoom.Account[A];
+				if (TargetAcc.MemberNumber == data.MemberNumber &&
 					// Cannot propose if on blacklist
-					Acc.ChatRoom.Account[A].BlackList.indexOf(Acc.MemberNumber) < 0
+					TargetAcc.BlackList.indexOf(Acc.MemberNumber) < 0
 				) {
 					// Cannot propose if owned by a NPC
-					if (Acc.ChatRoom.Account[A].Owner == null || Acc.ChatRoom.Account[A].Owner == "") {
+					if (TargetAcc.Owner == null || TargetAcc.Owner == "") {
 
 						// If there's no ownership, the dominant can propose to start a trial (Step 1 / 4)
-						if (Acc.ChatRoom.Account[A].Ownership == null || Acc.ChatRoom.Account[A].Ownership.MemberNumber == null) {
+						if (TargetAcc.Ownership == null || TargetAcc.Ownership.MemberNumber == null) {
 							if (data.Action === "Propose") {
-								Acc.ChatRoom.Account[A].Owner = "";
-								Acc.ChatRoom.Account[A].Ownership = { StartTrialOfferedByMemberNumber: Acc.MemberNumber };
-								ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "OfferStartTrial", "ServerMessage", Acc.ChatRoom.Account[A].MemberNumber, [{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber }]);
+								TargetAcc.Owner = "";
+								TargetAcc.Ownership = { StartTrialOfferedByMemberNumber: Acc.MemberNumber };
+								ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "OfferStartTrial", "ServerMessage", TargetAcc.MemberNumber, [{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber }]);
 							} else socket.emit("AccountOwnership", { MemberNumber: data.MemberNumber, Result: "CanOfferStartTrial" });
 						}
 
 						// If trial has started, the dominant can offer to end it after the delay (Step 3 / 4)
-						if (Acc.ChatRoom.Account[A].Ownership != null &&
-							Acc.ChatRoom.Account[A].Ownership.MemberNumber == Acc.MemberNumber &&
-							Acc.ChatRoom.Account[A].Ownership.EndTrialOfferedByMemberNumber == null &&
-							Acc.ChatRoom.Account[A].Ownership.Stage != null &&
-							Acc.ChatRoom.Account[A].Ownership.Start != null &&
-							Acc.ChatRoom.Account[A].Ownership.Stage == 0 &&
-							Acc.ChatRoom.Account[A].Ownership.Start + OwnershipDelay <= CommonTime()
+						if (TargetAcc.Ownership != null &&
+							TargetAcc.Ownership.MemberNumber == Acc.MemberNumber &&
+							TargetAcc.Ownership.EndTrialOfferedByMemberNumber == null &&
+							TargetAcc.Ownership.Stage != null &&
+							TargetAcc.Ownership.Start != null &&
+							TargetAcc.Ownership.Stage == 0 &&
+							TargetAcc.Ownership.Start + OwnershipDelay <= CommonTime()
 						) {
 							if (data.Action === "Propose") {
-								Acc.ChatRoom.Account[A].Ownership.EndTrialOfferedByMemberNumber = Acc.MemberNumber;
+								TargetAcc.Ownership.EndTrialOfferedByMemberNumber = Acc.MemberNumber;
 								ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "OfferEndTrial", "ServerMessage", null, [{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber }]);
 							} else socket.emit("AccountOwnership", { MemberNumber: data.MemberNumber, Result: "CanOfferEndTrial" });
 						}
@@ -1559,16 +1560,17 @@ function AccountOwnership(data, socket) {
 			(Acc.Ownership.MemberNumber == null || Acc.Ownership.MemberNumber == data.MemberNumber)
 		) {
 			for (var A = 0; A < Acc.ChatRoom.Account.length; A++) {
-				if (Acc.ChatRoom.Account[A].MemberNumber == data.MemberNumber &&
+				const TargetAcc = Acc.ChatRoom.Account[A];
+				if (TargetAcc.MemberNumber == data.MemberNumber &&
 					// Cannot accept if on blacklist
-					Acc.ChatRoom.Account[A].BlackList.indexOf(Acc.MemberNumber) < 0
+					TargetAcc.BlackList.indexOf(Acc.MemberNumber) < 0
 				) {
 
 					// If the submissive wants to accept to start the trial period (Step 2 / 4)
 					if (Acc.Ownership.StartTrialOfferedByMemberNumber != null && Acc.Ownership.StartTrialOfferedByMemberNumber == data.MemberNumber) {
 						if (data.Action === "Accept") {
 							Acc.Owner = "";
-							Acc.Ownership = { MemberNumber: data.MemberNumber, Name: Acc.ChatRoom.Account[A].Name, Start: CommonTime(), Stage: 0 };
+							Acc.Ownership = { MemberNumber: data.MemberNumber, Name: TargetAcc.Name, Start: CommonTime(), Stage: 0 };
 							var O = { Ownership: Acc.Ownership, Owner: Acc.Owner };
 							Database.collection("Accounts").updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
 							socket.emit("AccountOwnership", O);
@@ -1584,8 +1586,8 @@ function AccountOwnership(data, socket) {
 						Acc.Ownership.EndTrialOfferedByMemberNumber == data.MemberNumber
 					) {
 						if ((data.Action != null) && (typeof data.Action === "string") && (data.Action == "Accept")) {
-							Acc.Owner = Acc.ChatRoom.Account[A].Name;
-							Acc.Ownership = { MemberNumber: data.MemberNumber, Name: Acc.ChatRoom.Account[A].Name, Start: CommonTime(), Stage: 1 };
+							Acc.Owner = TargetAcc.Name;
+							Acc.Ownership = { MemberNumber: data.MemberNumber, Name: TargetAcc.Name, Start: CommonTime(), Stage: 1 };
 							var O = { Ownership: Acc.Ownership, Owner: Acc.Owner };
 							Database.collection("Accounts").updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
 							socket.emit("AccountOwnership", O);


### PR DESCRIPTION
~~**Depends on and includes #54**~~
~~*The reason for this dependency is, that the types tremendously help during development and safeguard against possible errors.*~~

- Rewrites `AccountOwnership` to be more readable and stable.
- Adds new targeted Action `Release`, enabling owners to release submissive from the bond.

Edit: Removed dependency