### PR TITLE
Fix friendlist friend type

### DIFF
--- a/app.js
+++ b/app.js
@@ -531,11 +531,13 @@ function AccountQuery(data, socket) {
 					for (var L = 0; L < Account[A].Lovership.length; L++) {
 						if (Account[A].Lovership[L].MemberNumber != null) { LoversNumbers.push(Account[A].Lovership[L].MemberNumber); }
 					}
-					if ((Account[A].Environment == Acc.Environment)
-						&& ((Account[A].Ownership != null) && (Account[A].Ownership.MemberNumber != null) && (Account[A].Ownership.MemberNumber == Acc.MemberNumber)
-							|| (LoversNumbers.indexOf(Acc.MemberNumber) >= 0))) {
-						Friends.push({ Type: "Submissive", MemberNumber: Account[A].MemberNumber, MemberName: Account[A].Name, ChatRoomSpace: (Account[A].ChatRoom == null) ? null : Account[A].ChatRoom.Space, ChatRoomName: (Account[A].ChatRoom == null) ? null : Account[A].ChatRoom.Name });
-						Index.push(Account[A].MemberNumber);
+					if (Account[A].Environment == Acc.Environment) {
+						var IsOwned = (Account[A].Ownership != null) && (Account[A].Ownership.MemberNumber != null) && (Account[A].Ownership.MemberNumber == Acc.MemberNumber);
+						var IsLover = LoversNumbers.indexOf(Acc.MemberNumber) >= 0;
+						if (IsOwned || IsLover) {
+							Friends.push({ Type: IsOwned ? "Submissive" : "Lover", MemberNumber: Account[A].MemberNumber, MemberName: Account[A].Name, ChatRoomSpace: (Account[A].ChatRoom == null) ? null : Account[A].ChatRoom.Space, ChatRoomName: (Account[A].ChatRoom == null) ? null : Account[A].ChatRoom.Name });
+							Index.push(Account[A].MemberNumber);
+						}
 					}
 				}
 


### PR DESCRIPTION
- fixed a bug where lovers were sent to the client with a submissive label, which would in turn be interpreted incorrectly if you broke up with the person.

This properly labels the player as a lover, and not a submissive when sending it out, which will stop new cases of this bug from occurring. (The client will correct those over time when opening the friendlist)