### PR TITLE
Optional admin/ban list on room creation

### DIFF
--- a/app.js
+++ b/app.js
@@ -732,6 +732,7 @@ function ChatRoomCreate(data, socket) {
 			if ((data.Space != null) && (typeof data.Space === "string") && (data.Space.length <= 100)) Space = data.Space;
 			if ((data.Game != null) && (typeof data.Game === "string") && (data.Game.length <= 100)) Game = data.Game;
 			if ((data.BlockCategory == null) || !Array.isArray(data.BlockCategory)) data.BlockCategory = [];
+			if ((data.Ban == null) || !Array.isArray(data.Ban) || data.Ban.some(i => !Number.isInteger(i))) data.Ban = [];
 
 			// Finds the account and links it to the new room
 			var Acc = AccountGet(socket.id);
@@ -751,7 +752,7 @@ function ChatRoomCreate(data, socket) {
 					Creator: Acc.Name,
 					Creation: CommonTime(),
 					Account: [],
-					Ban: [],
+					Ban: data.Ban,
 					BlockCategory: data.BlockCategory,
 					Admin: [Acc.MemberNumber]
 				};

--- a/app.js
+++ b/app.js
@@ -718,6 +718,8 @@ function ChatRoomCreate(data, socket) {
 		data.Name = data.Name.trim();
 		var LN = /^[a-zA-Z0-9 ]+$/;
 		if (data.Name.match(LN) && (data.Name.length >= 1) && (data.Name.length <= 20) && (data.Description.length <= 100) && (data.Background.length <= 100)) {
+			// Finds the account and links it to the new room
+			var Acc = AccountGet(socket.id);
 
 			// Check if the same name already exists and quits if that's the case
 			for (var C = 0; C < ChatRoom.length; C++)
@@ -733,6 +735,7 @@ function ChatRoomCreate(data, socket) {
 			if ((data.Game != null) && (typeof data.Game === "string") && (data.Game.length <= 100)) Game = data.Game;
 			if ((data.BlockCategory == null) || !Array.isArray(data.BlockCategory)) data.BlockCategory = [];
 			if ((data.Ban == null) || !Array.isArray(data.Ban) || data.Ban.some(i => !Number.isInteger(i))) data.Ban = [];
+			if ((data.Admin == null) || !Array.isArray(data.Admin) || data.Admin.some(i => !Number.isInteger(i))) data.Admin = [Acc.MemberNumber];
 
 			// Finds the account and links it to the new room
 			var Acc = AccountGet(socket.id);
@@ -754,7 +757,7 @@ function ChatRoomCreate(data, socket) {
 					Account: [],
 					Ban: data.Ban,
 					BlockCategory: data.BlockCategory,
-					Admin: [Acc.MemberNumber]
+					Admin: data.Admin
 				};
 				ChatRoom.push(NewRoom);
 				Acc.ChatRoom = NewRoom;

--- a/app.js
+++ b/app.js
@@ -737,8 +737,6 @@ function ChatRoomCreate(data, socket) {
 			if ((data.Ban == null) || !Array.isArray(data.Ban) || data.Ban.some(i => !Number.isInteger(i))) data.Ban = [];
 			if ((data.Admin == null) || !Array.isArray(data.Admin) || data.Admin.some(i => !Number.isInteger(i))) data.Admin = [Acc.MemberNumber];
 
-			// Finds the account and links it to the new room
-			var Acc = AccountGet(socket.id);
 			if (Acc != null) {
 				ChatRoomRemove(Acc, "ServerLeave", []);
 				var NewRoom = {


### PR DESCRIPTION
(note that the pr looks bigger than it actually is because I moved the `Acc == null` check to the beginning, the changes are small and consist just of the two lines to validate the data.Ban/data.Ban and using those values in the created room object)

- added support for including a ban/admin list when creating a room to reduce the amount of events required to get a room going

If this gets merged (or if you confirm it can be merged), 
Ill be able to go ahead with the planned refactor of autoban and room recreation (to remove the unnecessary room updates)
It will also allow us to add an input to list admins/banned people right from the start when we want to create a room

This does not have any compatibility issues with any version of the club