### PR TITLE
DC mitigation - Attempt 1

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,8 @@ var IO = new socketio.Server(App, {
 		credentials: true
 	},
 	maxHttpBufferSize: 200000,
-	pingTimeout: 20000,
+	pingTimeout: 30000,
+	pingInterval: 50000,
 	upgradeTimeout: 30000,
 	serveClient: false,
 	httpCompression: true,


### PR DESCRIPTION
- swapped `pingInterval` from 25s to 50s and `pingTimeout` from 20s to 30s (for the discussed reasons, Im appending the conversation so others can see)

If we try something else during beta 2, I'm curious to see the difference between this and 40s for each




> There are two important config values, pingInterval and pingTimeout right now they are set to 25s and 20s respectively. This means every 25s the server pings and expects a pong within 20 seconds. If we increase both values to around  50s and 30s, it would allow for a longer "grace period" which would likely reduce DC's by a lot since clients have 10 more seconds to respond to a ping. It would also reduce server load since there would be less ping/pong requests happening. The only "downside" is that the time to detect a proper DC is a little longer, so when you actually dc, you might realize it later than before. (I find the compromise reasonable considering dc's would be less frequent if the change works as expected)
> 
> A recent chrome update has also reduced what inactive tabs can do to save power and its been causing even more DCs in the club. The timer is around one minute so this change would likely help accomodate to this new reality (https://www.chromestatus.com/feature/4718288976216064)