### PR TITLE
Many reference issues and related fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -835,10 +835,10 @@ function ChatRoomRemove(Acc, Reason, Dictionary) {
 
 		// Destroys the room if it's empty, warn other players if not
 		if (Acc.ChatRoom.Account.length == 0) {
-			for (const Room of ChatRoom)
-				if (Acc.ChatRoom.Name == Room.Name) {
+			for (var C = 0; C < ChatRoom.length; C++)
+				if (Acc.ChatRoom.Name == ChatRoom[C].Name) {
 					console.log("Chat room " + Acc.ChatRoom.Name + " was destroyed. Rooms left: " + (ChatRoom.length - 1).toString());
-					ChatRoom.splice(ChatRoom.indexOf(Room), 1);
+					ChatRoom.splice(C, 1);
 					break;
 				}
 		} else {
@@ -1172,7 +1172,7 @@ function ChatRoomAdmin(data, socket) {
 					var LN = /^[a-zA-Z0-9 ]+$/;
 					if (data.Room.Name.match(LN) && (data.Room.Name.length >= 1) && (data.Room.Name.length <= 20) && (data.Room.Description.length <= 100) && (data.Room.Background.length <= 100)) {
 						for (const Room of ChatRoom)
-							if (Acc.ChatRoom && Room && Acc.ChatRoom.Name != data.Room.Name && Room.Name.toUpperCase().trim() == data.Room.Name.toUpperCase().trim()) {
+							if (Acc.ChatRoom && Acc.ChatRoom.Name != data.Room.Name && Room.Name.toUpperCase().trim() == data.Room.Name.toUpperCase().trim()) {
 								socket.emit("ChatRoomUpdateResponse", "RoomAlreadyExist");
 								return;
 							}
@@ -1743,7 +1743,7 @@ function AccountLovership(data, socket) {
 			// A player can accept a proposal from another one
 			if (((Acc.Lovership.length <= 5)) && (AL >= 0)) // No possible interaction if the player has reached the number of possible lovership or if isn't already a lover
 				for (const AccRoom of Acc.ChatRoom.Account)
-					if (AccRoom != null && (AccRoom.MemberNumber == data.MemberNumber) && (AccRoom.BlackList.indexOf(Acc.MemberNumber) < 0)) { // Cannot accept if on blacklist
+					if ((AccRoom.MemberNumber == data.MemberNumber) && (AccRoom.BlackList.indexOf(Acc.MemberNumber) < 0)) { // Cannot accept if on blacklist
 
 						var TargetLoversNumbers = [];
 						for (const AccRoomLover of AccRoom.Lovership) {

--- a/app.js
+++ b/app.js
@@ -783,11 +783,13 @@ function ChatRoomJoin(data, socket) {
 									if (Acc.ChatRoom == null || Acc.ChatRoom.ID !== Room.ID) {
 										ChatRoomRemove(Acc, "ServerLeave", []);
 										Acc.ChatRoom = Room;
-										Room.Account.push(Acc);
-										socket.join("chatroom-" + Room.ID);
-										socket.emit("ChatRoomSearchResponse", "JoinedRoom");
-										ChatRoomSyncMemberJoin(Room, Acc);
-										ChatRoomMessage(Room, Acc.MemberNumber, "ServerEnter", "Action", null, [{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber }]);
+										if (Account.find(A => Acc.MemberNumber === A.MemberNumber)) {
+											Room.Account.push(Acc);
+											socket.join("chatroom-" + Room.ID);
+											socket.emit("ChatRoomSearchResponse", "JoinedRoom");
+											ChatRoomSyncMemberJoin(Room, Acc);
+											ChatRoomMessage(Room, Acc.MemberNumber, "ServerEnter", "Action", null, [{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber }]);
+										}
 										return;
 									} else {
 										socket.emit("ChatRoomSearchResponse", "AlreadyInRoom");

--- a/app.js
+++ b/app.js
@@ -428,7 +428,7 @@ function ObjectEmpty(obj) {
 function AccountUpdate(data, socket) {
 	if ((data != null) && (typeof data === "object") && !Array.isArray(data))
 		for (const Acc of Account)
-			if (Acc != null && Acc.ID == socket.id) {
+			if (Acc.ID == socket.id) {
 
 				// Some data is never saved or updated from the client
 				delete data.Name;
@@ -586,7 +586,7 @@ function AccountBeep(data, socket) {
 		var Acc = AccountGet(socket.id);
 		if (Acc != null)
 			for (const OtherAcc of Account)
-				if (OtherAcc != null && OtherAcc.MemberNumber == data.MemberNumber)
+				if (OtherAcc.MemberNumber == data.MemberNumber)
 					if ((OtherAcc.Environment == Acc.Environment) && (((OtherAcc.FriendList != null) && (OtherAcc.FriendList.indexOf(Acc.MemberNumber) >= 0)) || ((OtherAcc.Ownership != null) && (OtherAcc.Ownership.MemberNumber != null) && (OtherAcc.Ownership.MemberNumber == Acc.MemberNumber)) || ((data.BeepType != null) && (typeof data.BeepType === "string") && (data.BeepType == "Leash")))) {
 						OtherAcc.Socket.emit("AccountBeep", {
 							MemberNumber: Acc.MemberNumber,
@@ -607,10 +607,12 @@ function AccountBeep(data, socket) {
 function AccountRemove(ID) {
 	if (ID != null)
 		for (const Acc of Account)
-			if (Acc != null && Acc.ID == ID) {
+			if (Acc.ID == ID) {
 				console.log("Disconnecting account: " + Acc.AccountName + " ID: " + ID);
 				ChatRoomRemove(Acc, "ServerDisconnect", []);
-				Account.splice(Account.indexOf(Acc), 1);
+				const index = Account.indexOf(Acc);
+				if (index >= 0)
+					Account.splice(index, 1);
 				break;
 			}
 }
@@ -618,7 +620,7 @@ function AccountRemove(ID) {
 // Returns the account object related to it's ID
 function AccountGet(ID) {
 	for (const Acc of Account)
-		if (Acc != null && Acc.ID == ID)
+		if (Acc.ID == ID)
 			return Acc;
 	return null;
 }
@@ -714,7 +716,7 @@ function ChatRoomCreate(data, socket) {
 
 			// Check if the same name already exists and quits if that's the case
 			for (const Room of ChatRoom)
-				if (Room != null && Room.Name.toUpperCase().trim() == data.Name.toUpperCase().trim()) {
+				if (Room.Name.toUpperCase().trim() == data.Name.toUpperCase().trim()) {
 					socket.emit("ChatRoomCreateResponse", "RoomAlreadyExist");
 					return;
 				}
@@ -773,7 +775,7 @@ function ChatRoomJoin(data, socket) {
 
 			// Finds the room and join it
 			for (const Room of ChatRoom)
-				if (Room != null && Room.Name.toUpperCase().trim() == data.Name.toUpperCase().trim())
+				if (Room.Name.toUpperCase().trim() == data.Name.toUpperCase().trim())
 					if (Acc.Environment == Room.Environment)
 						if (Room.Account.length < Room.Limit) {
 							if (Room.Ban.indexOf(Acc.MemberNumber) < 0) {
@@ -826,7 +828,7 @@ function ChatRoomRemove(Acc, Reason, Dictionary) {
 
 		// Removes it from the chat room array
 		for (const RoomAcc of Acc.ChatRoom.Account)
-			if (RoomAcc != null && RoomAcc.ID == Acc.ID) {
+			if (RoomAcc.ID == Acc.ID) {
 				Acc.ChatRoom.Account.splice(Acc.ChatRoom.Account.indexOf(RoomAcc), 1);
 				break;
 			}
@@ -834,7 +836,7 @@ function ChatRoomRemove(Acc, Reason, Dictionary) {
 		// Destroys the room if it's empty, warn other players if not
 		if (Acc.ChatRoom.Account.length == 0) {
 			for (const Room of ChatRoom)
-				if (Room != null && Acc.ChatRoom.Name == Room.Name) {
+				if (Acc.ChatRoom.Name == Room.Name) {
 					console.log("Chat room " + Acc.ChatRoom.Name + " was destroyed. Rooms left: " + (ChatRoom.length - 1).toString());
 					ChatRoom.splice(ChatRoom.indexOf(Room), 1);
 					break;
@@ -981,7 +983,7 @@ function ChatRoomSyncToMember(CR, SourceMemberNumber, TargetMemberNumber) {
 	// Sends the full packet to everyone in the room
 	for (const RoomAcc of CR.Account) // For each player in the chat room...
 	{
-		if(RoomAcc != null && RoomAcc.MemberNumber == TargetMemberNumber) // If the player is the one who gets synced...
+		if(RoomAcc.MemberNumber == TargetMemberNumber) // If the player is the one who gets synced...
 		{
 			// Send room data and break loop
 			RoomAcc.Socket.emit("ChatRoomSync", ChatRoomGetData(CR, SourceMemberNumber, true));
@@ -1082,7 +1084,7 @@ function ChatRoomCharacterUpdate(data, socket) {
 		if ((Acc != null) && (Acc.ChatRoom != null))
 			if (Acc.ChatRoom.Ban.indexOf(Acc.MemberNumber) < 0)
 				for (const RoomAcc of Acc.ChatRoom.Account)
-					if ((RoomAcc != null) && (RoomAcc.ID == data.ID) && ChatRoomGetAllowItem(Acc, RoomAcc))
+					if ((RoomAcc.ID == data.ID) && ChatRoomGetAllowItem(Acc, RoomAcc))
 						if ((typeof data.Appearance === "object") && Array.isArray(data.Appearance)) {
 							Database.collection("Accounts").updateOne({ AccountName: RoomAcc.AccountName }, { $set: { Appearance: data.Appearance } }, function(err, res) { if (err) throw err; });
 							RoomAcc.Appearance = data.Appearance;
@@ -1141,7 +1143,7 @@ function ChatRoomCharacterItemUpdate(data, socket) {
 		var Acc = AccountGet(socket.id);
 		if ((Acc == null) || (Acc.ChatRoom == null) || (Acc.ChatRoom.Ban.indexOf(Acc.MemberNumber) >= 0)) return;
 		for (const RoomAcc of Acc.ChatRoom.Account)
-			if (RoomAcc != null && RoomAcc.MemberNumber == data.Target && !ChatRoomGetAllowItem(Acc, RoomAcc))
+			if (RoomAcc.MemberNumber == data.Target && !ChatRoomGetAllowItem(Acc, RoomAcc))
 				return;
 
 		// Sends the item to use to everyone but the source
@@ -1360,7 +1362,7 @@ function ChatRoomAllowItem(data, socket) {
 		var Acc = AccountGet(socket.id);
 		if ((Acc != null) && (Acc.ChatRoom != null))
 			for (const RoomAcc of Acc.ChatRoom.Account)
-				if (RoomAcc != null && RoomAcc.MemberNumber == data.MemberNumber)
+				if (RoomAcc.MemberNumber == data.MemberNumber)
 					socket.emit("ChatRoomAllowItem", { MemberNumber: data.MemberNumber, AllowItem: ChatRoomGetAllowItem(Acc, RoomAcc) });
 
 	}
@@ -1627,8 +1629,8 @@ function AccountLovership(data, socket) {
 
 			var AccLoversNumbers = [];
 			for (const Lover of Acc.Lovership) {
-				if (Lover.MemberNumber != null) { AccLoversNumbers.push(Acc.Lovership[L].MemberNumber); }
-				else if (Lover.Name != null) { AccLoversNumbers.push(Acc.Lovership[L].Name); }
+				if (Lover.MemberNumber != null) { AccLoversNumbers.push(Lover.MemberNumber); }
+				else if (Lover.Name != null) { AccLoversNumbers.push(Lover.Name); }
 				else { AccLoversNumbers.push(-1); }
 			}
 			var AL = AccLoversNumbers.indexOf(data.MemberNumber);


### PR DESCRIPTION
This PR fixes many errors that have been hidden by null checks over the years, some bugs are clearly visible by reading the code, but many of them are oddities that are hard to trace back to this. I'll try to list all my findings:

The issues were discovered one by one after this fix was brought up: https://github.com/Ben987/Bondage-Club-Server/commit/56abb9274e55b02a01d2ea678f0418dfbc329fc1

All the added null checks fix cases where `Account[A]` was at the end of the Account array, then someone was removed from it (likely the account in question) and `Account[A]` becomes null, however it doesnt cover and hides cases where the array changed, and `Account[A]` is no longer the same. To fix this, we need to stop accessing indexes in `for` loops, and instead either store the account in a variable, use `forEach` or `for of`. I've used `for of` because it doesnt change the server logic, and fixes our issue since doing `for of` will guarantee that we loop through each object, and that the object reference remains the same within an iteration

**Explanation:**
The server has a lot of `for` loops which is very bad in our case, since the `Account`, `ChatRoom` or any `Account[A].Room.Account` array can change while looping through them. This is the reason why many null checks were added over the years, many which dont make any sense if you read the code as if it is perfectly synchronous. The logic is flawed the moment you realize that `Account[A]` may be different after an emit due to disconnect events being fired which in turn calls `AccountRemove` which alters the `Account` array, so the logic was never corrected and we have many cases where manipulations/syncs can be done on the wrong account, leading to useless syncs sent to the wrong person oe strange behavior depending on the case.

The overall logic is not changed beyond the fact that any manipulation is done on the same account from start to finish. If bugs are unearthed  (not very likely) because they rely on the currently broken logic, then we need to fix the logic.

**Known fixes:**
- fixed an **EXPLOIT** to find private rooms without knowing the name, bypass environment/bans/limits. (I wont describe it here to avoid griefing) / fixed a bug where you could join the wrong room
- Added a missing `break` in account beep to prevent looping through Account every time a beep is sent
- Fixed a bug where the server sends improper data in the `Lovership` array because `splice` is called in a `for` loop which messes up the indexes while iterating in cases where the splice is performed in the middle of the array
- Removed an unnecessary `JSON.stringify` in character update (performance gain). Socket.io limits the size via `maxHttpBufferSize` which we already have configured.
- chatroom clone bug (this happens because the account is added to the room after an emit, and the possibility of having handled a disconnect on the socket before pushing the account to the chatroom array means that the account can be "dc'ed but added", which also explains why each clone have a different online id. see line 781-783 from before these changes)


**Probable fixes: (these are all extremely rare and hard to reproduce, but technically possible and have been identified while correcting the code)**
- kicking the wrong person out of a room
- `AccountRemove `removing the wrong (one extra) account from the buffer when the account dc's during `ChatRoomRemove` of the initial `AccountRemove` This may be the cause of some wrongful disconnections or issues that require a relog (if your account was the one removed when it shouldnt be). See line 608-610 from before. The exact effects of this are hard to predict as the odds of it happening are extremely low
- chatroom-wide synchronizations that are not being spread to the entire room which can cause desyncs for one or multiple people because `Room.Account` is altered while iterating through it 
- since account can change in between,  #97 did not fix cases where the account is no longer the same. With this PR, it can no longer happen, therefore it fixes the issue for good 

I've tested as thoroughly as I could, Ellie and Jomshir have also tested and looked at the changes to make sure that stuff like lovers/owners/account creation/chatroom creation,update,delete/character sync/friendlist/etc. are still working as expected. Doing our best to reach all events, I found no issue.
This may fix more bugs than first thought as most of these issues are the type to cause bugs that are hard to track.