### PR TITLE
Paginated ChatRoomSearch

### DIFF
--- a/app.js
+++ b/app.js
@@ -764,7 +764,7 @@ function ChatRoomSearch(data, socket) {
 				if (Room.Ban.includes(Acc.MemberNumber)) continue;
 
 				// Skip rooms not matching search, if search was provided
-				if (data.Query != "" && Room.Name.toUpperCase().includes(data.Query)) continue;
+				if (data.Query != "" && !Room.Name.toUpperCase().includes(data.Query)) continue;
 
 				// Skip locked rooms, unless requester is admin
 				if (Room.Locked && !Room.Admin.includes(Acc.MemberNumber)) continue;

--- a/app.js
+++ b/app.js
@@ -802,19 +802,28 @@ function ChatRoomSearch(data, socket) {
 			const HasNext = CR.length > resultLimit;
 			if (HasNext) {
 				CR.pop();
+			} else {
+				// No cursor, if no next page
+				Cursor = null;
 			}
 
-			// Deprecated: Sends the list to the client
-			socket.emit("ChatRoomSearchResult", CR);
+			let Results;
+			switch (data.Version) {
+				case "2":
+					Results = {
+						Rooms: CR,
+						PageInfo: {
+							Cursor: Cursor,
+							HasNext: HasNext,
+						},
+					};
+					break;
+				default:
+					Results = CR;
+					break;
+			}
 
-			// Send paginated response to the client; this is a new event, because it is not backwards compatible with ChatRoomSearchResult
-			socket.emit("ChatRoomSearchResultV2", {
-				Rooms: CR,
-				PageInfo: {
-					Cursor: Cursor,
-					HasNext: HasNext,
-				},
-			});
+			socket.emit("ChatRoomSearchResult", Results);
 		}
 
 	}

--- a/app.js
+++ b/app.js
@@ -732,7 +732,7 @@ function ChatRoomSearch(data, socket) {
 				if (curr.Creation <= data.Cursor && (prev == -1 || curr.Creation > ChatRoom[prev].Creation)) {
 					return idx;
 				} else {
-					return -1;
+					return prev;
 				}
 			}, -1) : -1;
 			if (first == -1) {


### PR DESCRIPTION
The amount of public rooms in the club has been reaching above 61 potentially leaving some public rooms undiscoverable due to the limit in ChatRoomSearch.

![image](https://user-images.githubusercontent.com/98339032/161585530-4e665888-1cd0-4ee5-bcf8-cb3ebc9d59fe.png)

This change
- refactors ChatRoomSearch to be easier to read
- adds pagination support to ChatRoomSearch
- is backwards compatible; existing queries return the same results. New behavior requires a differently structured request (details below)

New optional parameters:
- `Version`: has to be `2` to enable new response format including pagination information (HasNext, Cursor in response)
- `Cursor`: a consistent pointer to the next page
- `Limit`: the amount of rooms per page to return (max and default 61 to match old behavior)

This will need to be followed up with a change to https://github.com/Ben987/Bondage-College/blob/master/BondageClub/Screens/Online/ChatSearch/ChatSearch.js to use the new request format and separately queried pages (ideally in R79 or R80).