### PR TITLE
Send the room Space back to the client

### DIFF
--- a/app.js
+++ b/app.js
@@ -1038,6 +1038,7 @@ function ChatRoomGetData(CR, SourceMemberNumber, IncludeCharacters)
 		Locked: CR.Locked,
 		Private: CR.Private,
 		BlockCategory: CR.BlockCategory,
+		Space: CR.Space,
 	};
 
 	if (IncludeCharacters) {


### PR DESCRIPTION
That makes it easier for the client; instead of having to guess what space they're in from the lobby they entered, just give them the real data.

Right now the client won't use it, but that gives an opportunity to cleanup the relogging, so it's likely I'll file a refactor PR on it later.