### PR TITLE
Fix a couple bugs with lovers and owners

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,7 +43,7 @@ var Options = {
 };
 if ((process.env.CORS_ORIGIN0 != null) && (process.env.CORS_ORIGIN0 != ""))
 	Options.cors = { origin: [process.env.CORS_ORIGIN0 || "", process.env.CORS_ORIGIN1 || "", process.env.CORS_ORIGIN2 || "", process.env.CORS_ORIGIN3 || "", process.env.CORS_ORIGIN4 || "", process.env.CORS_ORIGIN5 || ""] };
-else 
+else
 	Options.cors = { origin: '*' };
 var IO = new socketio.Server(App, Options);
 
@@ -482,7 +482,7 @@ async function AccountLoginProcess(socket, AccountName, Password) {
 	result.Socket = socket;
 	AccountSendServerInfo(socket);
 	AccountPurgeInfo(result);
-	
+
 }
 
 // Returns TRUE if the object is empty
@@ -1576,7 +1576,7 @@ function AccountOwnership(data, socket) {
 		// Can release a target that's not in the chatroom
 		if (!TargetAcc && (data.Action === "Release") && (Acc.MemberNumber != null) && (data.MemberNumber != null)) {
 
-			// Gets the account linked to that member number, make sure 
+			// Gets the account linked to that member number, make sure
 			Database.collection(AccountCollection).findOne({ MemberNumber : data.MemberNumber }, function(err, result) {
 				if (err) throw err;
 				if ((result != null) && (result.MemberNumber != null) && (result.MemberNumber === data.MemberNumber) && (result.Ownership != null) && (result.Ownership.MemberNumber === Acc.MemberNumber)) {
@@ -1628,6 +1628,9 @@ function AccountOwnership(data, socket) {
 
 					// If there's no ownership, the dominant can propose to start a trial (Step 1 / 4)
 					if (TargetAcc.Ownership == null || TargetAcc.Ownership.MemberNumber == null) {
+						// Ignore requests for self-owners
+						if (Acc.MemberNumber === data.MemberNumber) return;
+
 						if (data.Action === "Propose") {
 							TargetAcc.Owner = "";
 							TargetAcc.Ownership = { StartTrialOfferedByMemberNumber: Acc.MemberNumber };
@@ -1799,6 +1802,9 @@ function AccountLovership(data, socket) {
 							else { TargetLoversNumbers.push(-1); }
 						}
 						var TL = TargetLoversNumbers.indexOf(Acc.MemberNumber);
+
+						// Ignore requests for self-lovers
+						if (Acc.MemberNumber === RoomAcc.MemberNumber) return;
 
 						// If the target account is not a lover of player yet, can accept up to 5 loverships, one player can propose to start dating (Step 1 / 6)
 						if ((RoomAcc.Lovership.length < 5) && (TL < 0)) {

--- a/app.js
+++ b/app.js
@@ -1760,6 +1760,10 @@ function AccountLovership(data, socket) {
 						AccountUpdateLovership(P, data.MemberNumber, null,false);
 
 					}
+
+					// Make sure we don't do a double-delete in the odd case where we're breaking up with ourselves
+					if (data.MemberNumber === Acc.MemberNumber) return;
+
 					// Updates the account that triggered the break up
 					if (Array.isArray(Acc.Lovership)) Acc.Lovership.splice(AL, 1);
 					else Acc.Lovership = [];


### PR DESCRIPTION
This closes the hole allowing someone to either self-own or self-love, that has been known for a while and which people still seem to use. The server now ignores such messages, closing the loophole.

Additionally, there was a bug that would cause a second lover to be deleted in case you wanted to break up of your own lovership, as the removal would happen twice (once with us as the target, and the second time with us as the source). As the index we calculated for ourselves before running the "target removal" wasn't updated, when our own removal would happen this would remove another entry from the list. As that spurious removal was completely unexpected, that would also create an inconsistency, as the target didn't have us removed from their list, leading to a half-broken relationship.

This closes that bug, allowing people to stop their self-love relationship without fearing for another, truer one.

I've did a couple tests against the docker server, checking that NPC-lovership wasn't impacted, that the cheat commands used to create those self-relations wouldn't work anymore, and that both breaking ownership or lovership would still work.