### PR TITLE
Sync character on appearance change

### DIFF
--- a/app.js
+++ b/app.js
@@ -603,7 +603,7 @@ function AccountUpdate(data, socket) {
 				if ((data.Crafting != null)) Acc.Crafting = data.Crafting;
 
 				// Some changes should be synched to other players in chatroom
-				if ((Acc != null) && Acc.ChatRoom && ["AssetFamily", "Title", "Nickname", "Crafting", "Reputation", "Description", "LabelColor", "ItemPermission", "Inventory", "BlockItems", "LimitedItems", "FavoriteItems", "OnlineSharedSettings", "WhiteList", "BlackList"].some(k => data[k] != null))
+				if ((Acc != null) && Acc.ChatRoom && ["Appearance", "Title", "Nickname", "Crafting", "Reputation", "Description", "LabelColor", "ItemPermission", "Inventory", "BlockItems", "LimitedItems", "FavoriteItems", "OnlineSharedSettings", "WhiteList", "BlackList"].some(k => data[k] != null))
 					ChatRoomSyncCharacter(Acc.ChatRoom, Acc.MemberNumber, Acc.MemberNumber);
 
 				// If only the appearance is updated, we keep the change in memory and do not update the database right away


### PR DESCRIPTION
The latest changes also added a line to delete AssetFamily from the data of an account update, but Appearance wasn't in the list of attributes that caused the character to be synced, so the server stopped sending character sync messages in this case.

This removes AssetFamily from the list (since it can never be there anyway now as we delete it) and replaces it with Appearance, which should restore the server to sending the update it was sending previously.

This fixes the bug where crafted items didn't appear for you on the character you put them on, although that bug could probably be fixes with a CharacterRefresh client-side too. It seems like an update to Appearance here does need to cause a sync still, I think?