### PR TITLE
Make sure MaxHeapUsage is a number

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ var IO = new socketio.Server(App, Options);
 
 // Main game objects
 var BCrypt = require("bcrypt");
-var MaxHeapUsage = process.env.MAX_HEAP_USAGE || 16000000000; // 16 gigs allocated by default, can be altered server side
+var MaxHeapUsage = parseInt(process.env.MAX_HEAP_USAGE, 10) || 16_000_000_000; // 16 gigs allocated by default, can be altered server side
 var AccountCollection = process.env.ACCOUNT_COLLECTION || "Accounts";
 var Account = [];
 var ChatRoom = [];


### PR DESCRIPTION
This makes sure the variable has a `number` type, which TS doesn't like. It has no effect on the code if the environment variable is a proper number-string and would catch someone setting the heap limit as "foobar", defaulting it properly.