### PR TITLE
Fix possible race condition in lover breakup

### DIFF
--- a/app.js
+++ b/app.js
@@ -2322,27 +2322,30 @@ function AccountLovership(data, socket) {
 							for (const Lover of P)
 								TargetLoversNumbers.push(Lover.MemberNumber ? Lover.MemberNumber : -1);
 
-						if (Array.isArray(P)) P.splice(TargetLoversNumbers.indexOf(Acc.MemberNumber), 1);
-						else P = [];
+						var TL = TargetLoversNumbers.indexOf(Acc.MemberNumber);
+						// Don't try to remove an already removed lover
+						if (TL >= 0) {
+							if (Array.isArray(P)) P.splice(TL, 1);
+							else P = [];
 
-						for (const OtherAcc of Account)
-							if (OtherAcc.MemberNumber == data.MemberNumber) {
-								OtherAcc.Lovership = P;
-								OtherAcc.Socket.emit("AccountLovership", { Lovership: OtherAcc.Lovership });
-								if (OtherAcc.ChatRoom != null)
-									ChatRoomSyncCharacter(OtherAcc.ChatRoom, OtherAcc.MemberNumber, OtherAcc.MemberNumber);
-							}
+							for (const OtherAcc of Account)
+								if (OtherAcc.MemberNumber == data.MemberNumber) {
+									OtherAcc.Lovership = P;
+									OtherAcc.Socket.emit("AccountLovership", { Lovership: OtherAcc.Lovership });
+									if (OtherAcc.ChatRoom != null)
+										ChatRoomSyncCharacter(OtherAcc.ChatRoom, OtherAcc.MemberNumber, OtherAcc.MemberNumber);
+								}
 
-						AccountUpdateLovership(P, data.MemberNumber, null, false);
-
+							AccountUpdateLovership(P, data.MemberNumber, null, false);
+						}
 					}
 
 					// Make sure we don't do a double-delete in the odd case where we're breaking up with ourselves
 					if (data.MemberNumber === Acc.MemberNumber) return;
 
 					// Updates the account that triggered the break up
-					if (Array.isArray(Acc.Lovership)) Acc.Lovership.splice(AL, 1);
-					else Acc.Lovership = [];
+					if (!Array.isArray(Acc.Lovership)) Acc.Lovership = [];
+					else if (Acc.Lovership[AL].MemberNumber === data.MemberNumber) Acc.Lovership.splice(AL, 1);
 					AccountUpdateLovership(Acc.Lovership, Acc.MemberNumber);
 				});
 				return;


### PR DESCRIPTION
When breaking up with a lover, first the code checks that the specified member is still in the lover list in the in memory info, and if it does it initiates a mongodb query to get the other player, and only updates anything after it got the response. However, that query can even take around 30 seconds when the server is under load, and during that the profile still lists the lover the player tried to break up with. If they select break up again, with some (un)lucky timing the following can happen:

1. Player wants to break up with an other player, select the option in the chat room or club management
2. Checks the profile, sees the lover is still there, think it failed, and breaks up again
3. When the server receives the second `AccountLovership` query, the lover will still be in the `Lovership` array. Saves the index and does the mongodb query.
4. Meanwhile the previous mongodb query finishes. The lovers are removed from each other's list.
5. The second mongodb query runs after the previous update was done. `result[0].Lovership` will not contain the lover, so `TargetLoversNumbers.indexOf(Acc.MemberNumber)` will return -1.
6. What does `splice(-1, 1)` do? https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice -> Of course, it's javascript, so it removes the last item. So a completely unrelated lover is removed from the other player.
7. `Acc.Lovership.splice(AL, 1);` can also remove an unrelated lover since the index won't match after the previous update.

This PR fixes 6. by checking for a -1 result, and 7. by not removing the lovers if the index changed in the meantime. This will fix the case when someone is repeatedly trying to break up with someone, but could still end up in an inconsistent state if someone accepts/breaks up with multiple people during a short timeframe (but at least unintended people shouldn't be removed from the list).