### PR TITLE
Only show locked rooms if the client asks for them

### DIFF
--- a/Messages.d.ts
+++ b/Messages.d.ts
@@ -428,6 +428,7 @@ interface ServerChatRoomSearchRequest {
     Ignore?: string[];
 	Language: "" | ServerChatRoomLanguage | ServerChatRoomLanguage[];
     SearchDescs?: boolean;
+	ShowLocked?: boolean;
     MapTypes?: string[];
 }
 

--- a/app.js
+++ b/app.js
@@ -1159,6 +1159,9 @@ function ChatRoomSearch(data, socket) {
 		// Room is private, and query isn't an exact name match or player isn't a VIP, skip
 		if (room.Private && !(roomName === Query || isVIP)) continue;
 
+		// Room is locked and player isn't a VIP, skip
+		if (!data.ShowLocked && room.Locked && !isVIP) continue;
+
 		// Room is in our ignore list, skip
 		if (IgnoredRooms.includes(roomName)) continue;
 


### PR DESCRIPTION
After studying the behavior of the old client against the new server a little bit, it turns out there's a possibility of something odd happening with the relog code (not that it wouldn't also happen naturally). So, in order to impact the client as less as possible when the server gets the updated code, this puts the new show-locked-rooms behavior under an option. The old client will never set it, meaning it'll get the usual list, while the issue with the relog code can be fixed once it gets enabled, then the option can be removed and ignored, making it the default behavior.