### PR TITLE
Reverse the order in which search results are sent to the client

### DIFF
--- a/Messages.d.ts
+++ b/Messages.d.ts
@@ -437,6 +437,7 @@ interface ServerChatRoomSearchData {
     Language: string;
     Creator: string;
     CreatorMemberNumber: number;
+	Creation: number;
     MemberCount: number;
     MemberLimit: number;
     Description: string;

--- a/app.js
+++ b/app.js
@@ -1118,8 +1118,10 @@ function ChatRoomSearch(data, socket) {
 	}
 
 	// Builds a list of all public rooms, the last rooms created are shown first
+	const rooms = [...ChatRoom].reverse();
+
 	const CR = [];
-	for (const room of ChatRoom) {
+	for (const room of rooms) {
 		if (!room) continue;
 
 		const roomName = room.Name.toUpperCase();

--- a/app.js
+++ b/app.js
@@ -1209,6 +1209,7 @@ function ChatRoomSearchAddResult(Acc, room) {
 		Language: room.Language,
 		Creator: room.Creator,
 		CreatorMemberNumber: room.CreatorMemberNumber,
+		Creation: room.Creation,
 		MemberCount: room.Account.length,
 		MemberLimit: room.Limit,
 		Description: room.Description,


### PR DESCRIPTION
The old code did a reverse search through the chat to build the search results. Replace that code by making a copy of the ChatRoom array and reversing it.