### PR TITLE
feat(rooms): replace private/locked with granular visibility/access lists

### DIFF
--- a/Messages.d.ts
+++ b/Messages.d.ts
@@ -205,6 +205,7 @@ type ServerAppearanceBundle = ServerItemBundle[];
 
 type ServerChatRoomSpace = "X" | "" | "M" | "Asylum";
 type ServerChatRoomLanguage = "EN" | "DE" | "FR" | "ES" | "CN" | "RU" | "UA";
+type ServerChatRoomRole = "All" | "Admin" | "Whitelist";
 type ServerChatRoomGame = "" | "ClubCard" | "LARP" | "MagicBattle" | "GGTS";
 type ServerChatRoomBlockCategory =
 	/** Those are known as AssetCategory to the client */
@@ -227,8 +228,16 @@ type ServerChatRoomData = {
 	/* FIXME: server actually expects a string there, but we cheat to make the typing simpler */
 	Limit: number;
 	Game: ServerChatRoomGame;
-	Locked: boolean;
-	Private: boolean;
+	Visibility: ServerChatRoomRole[];
+	Access: ServerChatRoomRole[];
+	/**
+	 * @deprecated Use {@link ServerChatRoomData.Visibility} instead, this is temporarily maintained for backwards compatibility
+	 */
+	Private: boolean; // TODO: Remove following completion of migration
+	/**
+	 * @deprecated Use {@link ServerChatRoomData.Access} instead, this is temporarily maintained for backwards compatibility
+	 */
+	Locked: boolean; // TODO: Remove following completion of migration
 	BlockCategory: ServerChatRoomBlockCategory[];
 	Language: ServerChatRoomLanguage;
 	Space: ServerChatRoomSpace;
@@ -445,8 +454,16 @@ interface ServerChatRoomSearchData {
     Game: ServerChatRoomGame;
     Friends: ServerFriendInfo[];
     Space: ServerChatRoomSpace;
-    Locked: boolean;
-	Private: boolean;
+    Visibility: ServerChatRoomRole[];
+	Access: ServerChatRoomRole[];
+	/**
+	 * @deprecated Use {@link ServerChatRoomData.Visibility} instead, this is maintained for backwards compatibility
+	 */
+	Private?: boolean;
+	/**
+	 * @deprecated Use {@link ServerChatRoomData.Access} instead, this is maintained for backwards compatibility
+	 */
+	Locked?: boolean;
     MapType: string;
 }
 


### PR DESCRIPTION
These are the corresponding server changes necessary for the Visibility/Access list implementation, which [client!5237](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5327) is reliant upon. For more details on this change, see the linked MR.

As this directly pertains to the server code, I will additionally be going over the impact and current backward-compatability methodology of this change:
- The `Private` and `Locked` properties are intended to be sunset following the full release of the client functionality
- As there will be a transition period in which some clients are running the Visiblity/Access implementation and some are running the old Private/Locked implementation, there is a set of backward-compatability patches present in the code that should be removed following full release.
- The mechanics of the backward compatability patch are as follows:
	- All 4 of `Visibility`, `Access`, `Private`, and `Locked` are sent to the clients to ensure they get what they need to function
	- Visiblity <-> Private are cross-populated, meaning:
		- If Visibility is provided in a creation/update: Private is set to true if the Visibility is anything other than public
		- If Private is provided in a creation/update: Visibility is set to Admins Only, which matches existing functionality
		- If both are provided, the room data is considered invalid (there should never be a case where both are sent, as the new client uses Visibility, and the old client uses Private, never both)
		- If neither are provided, the room data is considered invalid (missing data)
	- Access <-> Locked are similarly cross-populated, meaning:
		- If Access is provided in a creation/update: Locked is set to true if the Access is anything other than public
		- If Locked is provided in a creation/update: Access is set to Admins + Whitelist Only, which matches >=R111 functionality
		- If both are provided, the room data is considered invalid (there should never be a case where both are sent, as the new client uses Access, and the old client uses Locked, never both)
		- If neither are provided, the room is defaulted to unlocked, which matches current expected behaviour (seems to be old backward-compatability behaviour that I've retained to be safe)
	- This ensures that the state of the room's visibility & access control remain consistent for both new & old clients.
	- A small inevitable caveat is that if an old client were to edit a room created by a new client who is utilizing the visibility/access mode functionality, the room will be overridden to use either public (private/locked off), or the strictest (private/locked on), replacing the new client's selected mode -- there is nothing that can be done about this without ignoring the old client's changes, which would be worse.
- A draft PR will be opened shortly which will contain the expected changes to remove the backward-compatability patches following full release.