### PR TITLE
revert: disallow whitelist from bypassing private

### DIFF
--- a/app.js
+++ b/app.js
@@ -1155,14 +1155,14 @@ function ChatRoomSearch(data, socket) {
 
 		}
 
-		// Keep track of whether the player is admin or whitelisted in the room
-		const isVIP = room.Admin.includes(Acc.MemberNumber) || room.Whitelist.includes(Acc.MemberNumber);
+		const isAdmin = room.Admin.includes(Acc.MemberNumber);
+		const isWhitelisted = room.Whitelist.includes(Acc.MemberNumber);
 
-		// Room is private, and query isn't an exact name match or player isn't a VIP, skip
-		if (room.Private && !(roomName === Query || isVIP)) continue;
+		// Room is private, and query isn't an exact name match or player isn't an admin, skip
+		if (room.Private && !(roomName === Query || isAdmin)) continue;
 
-		// Room is locked and player isn't a VIP, skip
-		if (!data.ShowLocked && room.Locked && !isVIP) continue;
+		// Room is locked and player isn't an admin or whitelisted, skip
+		if (!data.ShowLocked && room.Locked && !(isAdmin || isWhitelisted)) continue;
 
 		// Room is in our ignore list, skip
 		if (IgnoredRooms.includes(roomName)) continue;


### PR DESCRIPTION
Following [this](https://discord.com/channels/554377975714414605/1315008403722080298/1316561686744010752) discussion on Discord, it became clear that the functionality of whitelist bypassing private had unintended effects. This is a quick patch to revert that change, only allowing admins to bypass private rooms, and hence giving users an option to allow users to enter/leave a locked room, but not find it in the search.

The corresponding [client!5328](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5328) updates the UI to reflect this change.

This is a ***temporary quick fix*** (which should be implemented ***before the R111 release***) and in the long term, #212 should be used instead.