### PR TITLE
Added the CanJoin property to chat rooms when they are loaded.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1219,6 +1219,7 @@ function ChatRoomSearchAddResult(Acc, room) {
 		Locked: room.Locked,
 		Private: room.Private,
 		MapType: room?.MapData?.Type ?? "Never",
+		CanJoin: ChatRoomAccountHasAnyRole(Acc, room, room.Access),
 	}
 }
 


### PR DESCRIPTION
Revealed if the player can join a room through a new `CanJoin` property of returned room data objects. It is `true` if they can join and `false` if they cannot join. If the property somehow ends up `undefined`, the code on the client side will default to a lock icon, and no error will happen.

Coincides with a client side merge request: https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5421