### PR TITLE
Use argon2 for password hashes

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,7 +89,8 @@ const ROOM_LIMIT_MINIMUM = 2; // The minimum number of players in an online chat
 const ROOM_LIMIT_MAXIMUM = 20; // The maximum number of players in an online chat room
 
 // Limits the number of accounts created on each hour & day
-var AccountCreationIP = [];
+/** @type {{ Address: string, Time: number }[]} */
+const AccountCreationIP = [];
 const MAX_IP_ACCOUNT_PER_DAY = parseInt(process.env.MAX_IP_ACCOUNT_PER_DAY, 10) || 12;
 const MAX_IP_ACCOUNT_PER_HOUR = parseInt(process.env.MAX_IP_ACCOUNT_PER_HOUR, 10) || 4;
 
@@ -417,107 +418,104 @@ function CommonParseInt(thing, defaultValue = 0, base = 10) {
  * @param {ServerSocket} socket
  */
 function AccountCreate(data, socket) {
-
 	// Makes sure the account comes with a name and a password
-	if ((data != null) && (typeof data === "object") && (data.Name != null) && (data.AccountName != null) && (data.Password != null) && (data.Email != null) && (typeof data.Name === "string") && (typeof data.AccountName === "string") && (typeof data.Password === "string") && (typeof data.Email === "string")) {
+	if (!CommonIsObject(data) || typeof data.Name !== "string" || typeof data.AccountName !== "string" || typeof data.Email !== "string" || typeof data.Password !== "string") {
+		socket.emit("CreationResponse", "Invalid account information");
+		return;
+	}
 
-		// Makes sure the data is valid
-		if (data.Name.match(ServerCharacterNameRegex) && data.AccountName.match(ServerAccountNameRegex) && data.Password.match(ServerAccountPasswordRegex) && (CommonEmailIsValid(data.Email) || data.Email == "") && (data.Email.length <= 100)) {
+	// Makes sure the data is valid
+	if (!data.Name.match(ServerCharacterNameRegex)
+		|| !data.AccountName.match(ServerAccountNameRegex)
+		|| !data.Password.match(ServerAccountPasswordRegex)
+		|| data.Email !== "" && !CommonEmailIsValid(data.Email)) {
+			socket.emit("CreationResponse", "Invalid account information");
+			return;
+	}
 
-			// Gets the current IP Address that's creating the account
-			/** @type {string} */
-			let CurrentIP = socket.conn.remoteAddress;
-			if (IP_CONNECTION_PROXY_HEADER && typeof socket.handshake.headers[IP_CONNECTION_PROXY_HEADER] === "string") {
-				const hops = /** @type {string} */ (socket.handshake.headers[IP_CONNECTION_PROXY_HEADER]).split(",");
-				CurrentIP = hops[hops.length-1].trim();
+	// Gets the current IP Address that's creating the account
+	/** @type {string} */
+	let CurrentIP = socket.conn.remoteAddress;
+	if (IP_CONNECTION_PROXY_HEADER && typeof socket.handshake.headers[IP_CONNECTION_PROXY_HEADER] === "string") {
+		const hops = /** @type {string} */ (socket.handshake.headers[IP_CONNECTION_PROXY_HEADER]).split(",");
+		CurrentIP = hops[hops.length-1].trim();
+	}
+
+	// If the IP is valid
+	if ((CurrentIP != null) && (CurrentIP != "")) {
+		// Checks the number of account created in total and in the last hour by this IP
+		let CurrentTime = CommonTime();
+		let TotalCount = 0;
+		let HourCount = 0;
+		for (let IP of AccountCreationIP)
+			if (IP.Address === CurrentIP) {
+				TotalCount++;
+				if (IP.Time >= CurrentTime - 3600000) HourCount++;
 			}
 
-			// If the IP is valid
-			if ((CurrentIP != null) && (CurrentIP != "")) {
+		/*var mailOptions = {
+			from: "donotreply@bondageprojects.com",
+			to: process.env.EMAIL_ADMIN || "",
+			subject: "Bondage Club Server Info",
+			html: "IP: " + CurrentIP + " is creating account: " + data.AccountName + " at time: " + CommonTime().toString() + "<br />TotalCount: " + TotalCount.toString() + "<br />MAX_IP_ACCOUNT_PER_DAY: " + MAX_IP_ACCOUNT_PER_DAY.toString() + "<br />HourCount: " + HourCount.toString() + "<br />MAX_IP_ACCOUNT_PER_HOUR: " + MAX_IP_ACCOUNT_PER_HOUR.toString()
+		};
+		MailTransporter.sendMail(mailOptions, function (err, info) {});*/
 
-				// Checks the number of account created in total and in the last hour by this IP
-				let CurrentTime = CommonTime();
-				let TotalCount = 0;
-				let HourCount = 0;
-				for (let IP of AccountCreationIP)
-					if (IP.Address === CurrentIP) {
-						TotalCount++;
-						if (IP.Time >= CurrentTime - 3600000) HourCount++;
-					}
-
-				/*var mailOptions = {
-					from: "donotreply@bondageprojects.com",
-					to: process.env.EMAIL_ADMIN || "",
-					subject: "Bondage Club Server Info",
-					html: "IP: " + CurrentIP + " is creating account: " + data.AccountName + " at time: " + CommonTime().toString() + "<br />TotalCount: " + TotalCount.toString() + "<br />MAX_IP_ACCOUNT_PER_DAY: " + MAX_IP_ACCOUNT_PER_DAY.toString() + "<br />HourCount: " + HourCount.toString() + "<br />MAX_IP_ACCOUNT_PER_HOUR: " + MAX_IP_ACCOUNT_PER_HOUR.toString()
-				};
-				MailTransporter.sendMail(mailOptions, function (err, info) {});*/
-
-				// Exits if we reached the limit
-				if ((TotalCount >= MAX_IP_ACCOUNT_PER_DAY) || (HourCount >= MAX_IP_ACCOUNT_PER_HOUR)) {
-					socket.emit("CreationResponse", "New accounts per day exceeded");
-					return;
-				}
-
-				// Keeps the IP in memory for the next run
-				AccountCreationIP.push({ Address: CurrentIP, Time: CurrentTime });
-
-			}
-
-			// Checks if the account already exists
-			data.AccountName = data.AccountName.toUpperCase();
-			Database.collection(AccountCollection).findOne({ AccountName : data.AccountName }, function(err, result) {
-
-				// Makes sure the result is null so the account doesn't already exists
-				if (err) throw err;
-				if (result != null) {
-					socket.emit("CreationResponse", "Account already exists");
-				} else {
-
-					// Creates a hashed password and saves it with the account info
-					BCrypt.hash(data.Password.toUpperCase(), 10, function( err, hash ) {
-						if (err) throw err;
-						let account = /** @type {Account} */ ({
-							// ID and Socket are special; they're used at runtime but cannot be
-							// persisted to the database so they're set after that happens.
-							AccountName: data.AccountName,
-							Email: data.Email,
-							Password: hash,
-							// Use the next member number and bump it
-							MemberNumber: NextMemberNumber++,
-							Name: data.Name,
-							Money: 100,
-							Creation: CommonTime(),
-							LastLogin: CommonTime(),
-							Environment: AccountGetEnvironment(socket),
-							Lovership: [],
-							ItemPermission: 2,
-							FriendList: [],
-							WhiteList: [],
-							BlackList: [],
-						});
-						Database.collection(AccountCollection).insertOne(account, function(err, res) {
-							if (err) throw err;
-							account.ID = socket.id;
-							account.Socket = socket;
-							console.log("Creating new account: " + account.AccountName + " ID: " + socket.id + " " + account.Environment);
-							AccountValidData(account);
-							Account.push(account);
-							OnLogin(socket);
-							socket.emit("CreationResponse", { ServerAnswer: "AccountCreated", OnlineID: account.ID, MemberNumber: account.MemberNumber } );
-							AccountSendServerInfo(socket);
-							AccountPurgeInfo(data);
-						});
-					});
-
-				}
-
-			});
-
+		// Exits if we reached the limit
+		if ((TotalCount >= MAX_IP_ACCOUNT_PER_DAY) || (HourCount >= MAX_IP_ACCOUNT_PER_HOUR)) {
+			socket.emit("CreationResponse", "New accounts per day exceeded");
+			return;
 		}
 
-	} else socket.emit("CreationResponse", "Invalid account information");
+		// Keeps the IP in memory for the next run
+		AccountCreationIP.push({ Address: CurrentIP, Time: CurrentTime });
+	}
 
+	// Checks if the account already exists
+	data.AccountName = data.AccountName.toUpperCase();
+	Database.collection(AccountCollection).findOne({ AccountName: data.AccountName }, async function(err, result) {
+
+		// Makes sure the result is null so the account doesn't already exists
+		if (err) throw err;
+		if (result != null) {
+			socket.emit("CreationResponse", "Account already exists");
+			return;
+		}
+
+		// Creates a hashed password and saves it with the account info
+		const hash = await BCrypt.hash(data.Password.toUpperCase(), 10);
+		let account = /** @type {Account} */ ({
+			// ID and Socket are special; they're used at runtime but cannot be
+			// persisted to the database so they're set after that happens.
+			AccountName: data.AccountName,
+			Email: data.Email,
+			Password: hash,
+			// Use the next member number and bump it
+			MemberNumber: NextMemberNumber++,
+			Name: data.Name,
+			Money: 100,
+			Creation: CommonTime(),
+			LastLogin: CommonTime(),
+			Environment: AccountGetEnvironment(socket),
+			Lovership: [],
+			ItemPermission: 2,
+			FriendList: [],
+			WhiteList: [],
+			BlackList: [],
+		});
+		Database.collection(AccountCollection).insertOne(account, function(err, res) {
+			if (err) throw err;
+			account.ID = socket.id;
+			account.Socket = socket;
+			console.log("Creating new account: " + account.AccountName + " ID: " + socket.id + " " + account.Environment);
+			AccountValidData(account);
+			Account.push(account);
+			OnLogin(socket);
+			socket.emit("CreationResponse", { ServerAnswer: "AccountCreated", OnlineID: account.ID, MemberNumber: account.MemberNumber } );
+			AccountSendServerInfo(socket);
+			AccountPurgeInfo(data);
+		});
+	});
 }
 
 /**

--- a/app.js
+++ b/app.js
@@ -53,6 +53,7 @@ var IO = new socketio.Server(App, Options);
 
 // Main game objects
 var BCrypt = require("bcrypt");
+const argon2 = require("argon2");
 var MaxHeapUsage = parseInt(process.env.MAX_HEAP_USAGE, 10) || 16_000_000_000; // 16 gigs allocated by default, can be altered server side
 var AccountCollection = process.env.ACCOUNT_COLLECTION || "Accounts";
 /** @type {Account[]} */
@@ -483,7 +484,7 @@ function AccountCreate(data, socket) {
 		}
 
 		// Creates a hashed password and saves it with the account info
-		const hash = await BCrypt.hash(data.Password, 10);
+		const hash = await argon2.hash(data.Password);
 		let account = /** @type {Account} */ ({
 			// ID and Socket are special; they're used at runtime but cannot be
 			// persisted to the database so they're set after that happens.
@@ -665,14 +666,14 @@ async function AccountLoginProcess(socket, AccountName, Password) {
 	}
 
 	// All of the password checking
-	if (await BCrypt.compare(Password, result.Password)) {
-		// All good
-	} else if (await BCrypt.compare(Password.toUpperCase(), result.Password)) {
-		if (Password !== result.Password) {
-			// casing is different, upgrade stored version **assuming** this is the casing people use generally
-			result.Password = await BCrypt.hash(Password, 10);
+	if (result.Password.startsWith('$argon2id$') && await argon2.verify(Password, result.Password)) {
+		if (argon2.needsRehash(result.Password, { })) {
+			result.Password = await argon2.hash(Password);
 			await Database.collection(AccountCollection).update({ AccountName }, { $set: { Password: result.Password } });
 		}
+	} else if (result.Password.startsWith('$2') && (await BCrypt.compare(Password, result.Password) || await BCrypt.compare(Password.toUpperCase(), result.Password))) {
+		result.Password = await argon2.hash(Password);
+		await Database.collection(AccountCollection).update({ AccountName }, { $set: { Password: result.Password } });
 	} else {
 		if (!socket.connected) return;
 		socket.emit("LoginResponse", "InvalidNamePassword");
@@ -2293,7 +2294,7 @@ function PasswordReset(data, socket) {
  * @param {ServerPasswordResetProcessRequest} data
  * @param {ServerSocket} socket
  */
-function PasswordResetProcess(data, socket) {
+async function PasswordResetProcess(data, socket) {
 	if (!CommonIsObject(data) || typeof data.AccountName !== "string" || typeof data.ResetNumber !== "string" || typeof data.NewPassword !== "string") {
 		socket.emit("PasswordResetResponse", "InvalidPasswordResetInfo");
 		return;
@@ -2314,12 +2315,12 @@ function PasswordResetProcess(data, socket) {
 	}
 
 	// Creates a hashed password and updates the account with it
-	BCrypt.hash(data.NewPassword, 10, function(err, hash) {
-		if (err) throw err;
-		console.log("Updating password for account: " + data.AccountName);
-		Database.collection(AccountCollection).updateOne({ AccountName: data.AccountName }, { $set: { Password: hash } }, function(err, res) { if (err) throw err; });
-		socket.emit("PasswordResetResponse", "PasswordResetSuccessful");
-	});
+	console.log("Updating password for account: " + data.AccountName);
+	const hash = await argon2.hash(data.NewPassword);
+
+	await Database.collection(AccountCollection).updateOne({ AccountName: data.AccountName }, { $set: { Password: hash } });
+	socket.emit("PasswordResetResponse", "PasswordResetSuccessful");
+
 }
 
 /**

--- a/app.js
+++ b/app.js
@@ -483,7 +483,7 @@ function AccountCreate(data, socket) {
 		}
 
 		// Creates a hashed password and saves it with the account info
-		const hash = await BCrypt.hash(data.Password.toUpperCase(), 10);
+		const hash = await BCrypt.hash(data.Password, 10);
 		let account = /** @type {Account} */ ({
 			// ID and Socket are special; they're used at runtime but cannot be
 			// persisted to the database so they're set after that happens.
@@ -652,6 +652,8 @@ function AccountRemoveFromChatRoom(MemberNumber) {
  * @param {string} Password
  */
 async function AccountLoginProcess(socket, AccountName, Password) {
+	if (!socket.connected) return;
+
 	// Checks if there's an account that matches the name
 	/** @type {Account|null} */
 	const result = await Database.collection(AccountCollection).findOne({ AccountName });
@@ -662,14 +664,22 @@ async function AccountLoginProcess(socket, AccountName, Password) {
 		return;
 	}
 
-	// Compare the password to its hashed version
-	const res = await BCrypt.compare(Password.toUpperCase(), result.Password);
-
-	if (!socket.connected) return;
-	if (!res) {
+	// All of the password checking
+	if (await BCrypt.compare(Password, result.Password)) {
+		// All good
+	} else if (await BCrypt.compare(Password.toUpperCase(), result.Password)) {
+		if (Password !== result.Password) {
+			// casing is different, upgrade stored version **assuming** this is the casing people use generally
+			result.Password = await BCrypt.hash(Password, 10);
+			await Database.collection(AccountCollection).update({ AccountName }, { $set: { Password: result.Password } });
+		}
+	} else {
+		if (!socket.connected) return;
 		socket.emit("LoginResponse", "InvalidNamePassword");
 		return;
 	}
+
+	if (!socket.connected) return;
 
 	// Disconnect duplicated logged accounts
 	for (const Acc of Account) {
@@ -2304,7 +2314,7 @@ function PasswordResetProcess(data, socket) {
 	}
 
 	// Creates a hashed password and updates the account with it
-	BCrypt.hash(data.NewPassword.toUpperCase(), 10, function(err, hash) {
+	BCrypt.hash(data.NewPassword, 10, function(err, hash) {
 		if (err) throw err;
 		console.log("Updating password for account: " + data.AccountName);
 		Database.collection(AccountCollection).updateOne({ AccountName: data.AccountName }, { $set: { Password: hash } }, function(err, res) { if (err) throw err; });

--- a/app.js
+++ b/app.js
@@ -2226,53 +2226,58 @@ function PasswordResetSetNumber(AccountName, ResetNumber) {
  * @param {ServerSocket} socket
  */
 function PasswordReset(data, socket) {
-	if ((data != null) && (typeof data === "string") && (data != "") && CommonEmailIsValid(data)) {
-
-		// One email reset password per 5 seconds to prevent flooding
-		if (NextPasswordReset > CommonTime()) return socket.emit("PasswordResetResponse", "RetryLater");
-		NextPasswordReset = CommonTime() + 5000;
-
-		// Gets all accounts that matches the email
-		Database.collection(AccountCollection).find({ Email : data }).toArray(function(err, result) {
-
-			// If we found accounts with that email
-			if (err) throw err;
-			if ((result != null) && (typeof result === "object") && (result.length > 0)) {
-
-				// Builds a reset number for each account found and creates the email body
-				var EmailBody = "To reset your account password, enter your account name and the reset number included in this email.  You need to put these in the Bondage Club password reset screen, with your new password.<br /><br />";
-				for (const res of result) {
-					var ResetNumber = (Math.round(Math.random() * 1000000000000)).toString();
-					PasswordResetSetNumber(res.AccountName, ResetNumber);
-					EmailBody = EmailBody + "Account Name: " + res.AccountName + "<br />";
-					EmailBody = EmailBody + "Reset Number: " + ResetNumber + "<br /><br />";
-				}
-
-				// Prepares the email to be sent
-				var mailOptions = {
-					from: "donotreply@bondageprojects.com",
-					to: result[0].Email,
-					subject: "Bondage Club Password Reset",
-					html: EmailBody
-				};
-
-				// Sends the email and logs the result
-				MailTransporter.sendMail(mailOptions, function (err, info) {
-					if (err) {
-						console.log("Error while sending password reset email: " + err);
-						socket.emit("PasswordResetResponse", "EmailSentError");
-					}
-					else {
-						console.log("Password reset email send to: " + result[0].Email);
-						socket.emit("PasswordResetResponse", "EmailSent");
-					}
-				});
-
-			} else socket.emit("PasswordResetResponse", "NoAccountOnEmail");
-
-		});
-
+	if (typeof data !== "string" || !CommonEmailIsValid(data)) {
+		// socket.emit("PasswordResetResponse", "InvalidEmail");
+		return;
 	}
+
+	// One email reset password per 5 seconds to prevent flooding
+	if (NextPasswordReset > CommonTime()) {
+		socket.emit("PasswordResetResponse", "RetryLater");
+		return;
+	}
+	NextPasswordReset = CommonTime() + 5000;
+
+	// Gets all accounts that matches the email
+	Database.collection(AccountCollection).find({ Email : data }).toArray(function(err, result) {
+		if (err) {
+			throw err;
+		}
+
+		if (!Array.isArray(result) || result.length === 0) {
+			socket.emit("PasswordResetResponse", "NoAccountOnEmail");
+			return;
+		}
+
+		// If we found accounts with that email
+		// Builds a reset number for each account found and creates the email body
+		let EmailBody = "To reset your account password, enter your account name and the reset number included in this email.  You need to put these in the Bondage Club password reset screen, with your new password.<br /><br />";
+		for (const res of result) {
+			const ResetNumber = (Math.round(Math.random() * 1000000000000)).toString();
+			PasswordResetSetNumber(res.AccountName, ResetNumber);
+			EmailBody = EmailBody + "Account Name: " + res.AccountName + "<br />";
+			EmailBody = EmailBody + "Reset Number: " + ResetNumber + "<br /><br />";
+		}
+
+		// Prepares the email to be sent
+		const mailOptions = {
+			from: "donotreply@bondageprojects.com",
+			to: result[0].Email,
+			subject: "Bondage Club Password Reset",
+			html: EmailBody
+		};
+
+		// Sends the email and logs the result
+		MailTransporter.sendMail(mailOptions, function (err, info) {
+			if (err) {
+				console.log("Error while sending password reset email: " + err);
+				socket.emit("PasswordResetResponse", "EmailSentError");
+			} else {
+				console.log("Password reset email send to: " + result[0].Email);
+				socket.emit("PasswordResetResponse", "EmailSent");
+			}
+		});
+	});
 }
 
 /**
@@ -2281,31 +2286,32 @@ function PasswordReset(data, socket) {
  * @param {ServerSocket} socket
  */
 function PasswordResetProcess(data, socket) {
-	if ((data != null) && (typeof data === "object") && (data.AccountName != null) && (typeof data.AccountName === "string") && (data.ResetNumber != null) && (typeof data.ResetNumber === "string") && (data.NewPassword != null) && (typeof data.NewPassword === "string")) {
+	if (!CommonIsObject(data) || typeof data.AccountName !== "string" || typeof data.ResetNumber !== "string" || typeof data.NewPassword !== "string") {
+		socket.emit("PasswordResetResponse", "InvalidPasswordResetInfo");
+		return;
+	}
 
-		// Makes sure the data is valid
-		if (data.AccountName.match(ServerAccountNameRegex) && data.NewPassword.match(ServerAccountPasswordRegex)) {
+	// Makes sure the data is valid
+	if (!data.AccountName.match(ServerAccountNameRegex) || !data.NewPassword.match(ServerAccountPasswordRegex)) {
+		socket.emit("PasswordResetResponse", "InvalidPasswordResetInfo");
+		return;
+	}
 
-			// Checks if the reset number matches
-			for (const PasswordReset of PasswordResetProgress)
-				if ((PasswordReset.AccountName == data.AccountName) && (PasswordReset.ResetNumber == data.ResetNumber)) {
+	// Find the request for that account and number
+	const resetRequest = PasswordResetProgress.find(req => req.AccountName === data.AccountName && req.ResetNumber === data.ResetNumber);
+	if (!resetRequest) {
+		// Sends a fail message to the client
+		socket.emit("PasswordResetResponse", "InvalidPasswordResetInfo");
+		return;
+	}
 
-					// Creates a hashed password and updates the account with it
-					BCrypt.hash(data.NewPassword.toUpperCase(), 10, function( err, hash ) {
-						if (err) throw err;
-						console.log("Updating password for account: " + data.AccountName);
-						Database.collection(AccountCollection).updateOne({ AccountName : data.AccountName }, { $set: { Password: hash } }, function(err, res) { if (err) throw err; });
-						socket.emit("PasswordResetResponse", "PasswordResetSuccessful");
-					});
-					return;
-				}
-
-			// Sends a fail message to the client
-			socket.emit("PasswordResetResponse", "InvalidPasswordResetInfo");
-
-		} else socket.emit("PasswordResetResponse", "InvalidPasswordResetInfo");
-
-	} else socket.emit("PasswordResetResponse", "InvalidPasswordResetInfo");
+	// Creates a hashed password and updates the account with it
+	BCrypt.hash(data.NewPassword.toUpperCase(), 10, function(err, hash) {
+		if (err) throw err;
+		console.log("Updating password for account: " + data.AccountName);
+		Database.collection(AccountCollection).updateOne({ AccountName: data.AccountName }, { $set: { Password: hash } }, function(err, res) { if (err) throw err; });
+		socket.emit("PasswordResetResponse", "PasswordResetSuccessful");
+	});
 }
 
 /**

--- a/app.js
+++ b/app.js
@@ -177,7 +177,7 @@ const IPConnections = new Map();
 // These regex must be kept in sync with the client
 const ServerAccountEmailRegex = /^[a-zA-Z0-9@.!#$%&'*+/=?^_`{|}~-]{5,100}$/;
 const ServerAccountNameRegex = /^[a-zA-Z0-9]{1,20}$/;
-const ServerAccountPasswordRegex = /^[a-zA-Z0-9]{1,20}$/;
+const ServerAccountPasswordRegex = /^[a-zA-Z0-9`~!@#$%^&*()_\-+={}|[\]:";'<>?,.]{1,100}$/;
 const ServerAccountResetNumberRegex = /^[0-9]{1,20}$/;
 const ServerCharacterNameRegex = /^[a-zA-Z ]{1,20}$/;
 const ServerCharacterNicknameRegex = /^[\p{L}\p{Nd}\p{Z}'-]+$/u;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bondage-club-server",
       "version": "1.0.0",
       "dependencies": {
+        "argon2": "^0.44.0",
         "base64id": "^2.0.0",
         "bcrypt": "^5.1.1",
         "mongodb": "^3.7.4",
@@ -43,6 +44,12 @@
       "engines": {
         "node": ">=12.13.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.10.9",
@@ -228,6 +235,15 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -460,6 +476,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/argon2/node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/argparse": {
@@ -871,11 +912,27 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "optional": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -888,14 +945,12 @@
     "node_modules/cross-spawn/node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "optional": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -2263,10 +2318,10 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
-      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
-      "optional": true,
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -2406,7 +2461,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2720,7 +2774,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "optional": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2732,7 +2785,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "docker:logs": "docker-compose logs -f app db"
   },
   "dependencies": {
+    "argon2": "^0.44.0",
     "base64id": "^2.0.0",
     "bcrypt": "^5.1.1",
     "mongodb": "^3.7.4",


### PR DESCRIPTION
As the security standard is now argon2 (because of stronger resistance against GPU-based attacks), switch to use that hash type for our passwords. This is based on #230, so it has the same effect of no longer limiting to uppercase and adding more symbols, and works the same way: on login, any old BCrypt hash will be upgraded to argon2.