### PR TITLE
New Ownership Property: Notes

### DIFF
--- a/Messages.d.ts
+++ b/Messages.d.ts
@@ -171,6 +171,7 @@ type ServerAccountDataSynced = Omit<ServerAccountData, "Money" | "FriendList" | 
 interface ServerOwnership {
 	MemberNumber?: number;
 	Name?: string;
+	Notes?: string;  // Public notes from this sub's owner.
 	Stage?: number;
 	Start?: number;
 	StartTrialOfferedByMemberNumber?: number;
@@ -402,10 +403,18 @@ interface ServerAccountLovershipComplete {
 
 type ServerAccountLovershipResponse = ServerAccountLovershipStatus | ServerAccountLovershipInfo | ServerAccountLovershipComplete;
 
-interface ServerAccountOwnershipRequest {
+interface ServerAccountOwnershipAcquisitionRequest {
 	MemberNumber: number;
 	Action?: "Propose" | "Accept" | "Release" | "Break";
 }
+
+interface ServerAccountOwnershipUpdateNotesRequest {
+	MemberNumber: number;
+	Action: "UpdateNotes";
+	Notes?: string;
+}
+
+type ServerAccountOwnershipRequest = ServerAccountOwnershipAcquisitionRequest | ServerAccountOwnershipUpdateNotesRequest;
 
 interface ServerAccountOwnershipStatus {
     MemberNumber: number;

--- a/app.js
+++ b/app.js
@@ -2362,18 +2362,17 @@ function AccountOwnership(data, socket) {
 		// Exit if there's no target
 		if (!TargetAcc) return;
 
-		// The dominant is setting/updating public notes on their submissive.
+		// The dominant is setting/updating public notes on their fully owned submissive.
 		if (    data.Action === "UpdateNotes"
-		    &&  TargetAcc.Owner != null
-		    &&  TargetAcc.Owner !== ""
 		    &&  TargetAcc.Ownership != null
+		    &&  TargetAcc.Ownership.Stage === 1
 		    &&  TargetAcc.Ownership.MemberNumber == Acc.MemberNumber)
 		{
 			if (typeof data.Notes === "string"  &&  data.Notes.length > 0) {
 				// FIXME: This isn't fully Unicode-aware.
 				TargetAcc.Ownership.Notes = data.Notes.slice (0, 10000);
 			} else {
-				TargetAcc.Ownership.Notes = null;
+				TargetAcc.Ownership.Notes = undefined;
 			}
 			let O = { Ownership: TargetAcc.Ownership, Owner: TargetAcc.Owner };
 			Database.collection(AccountCollection).updateOne (

--- a/app.js
+++ b/app.js
@@ -2358,30 +2358,30 @@ function AccountOwnership(data, socket) {
 			});
 		}
 
-
 		// Exit if there's no target
 		if (!TargetAcc) return;
 
 		// The dominant is setting/updating public notes on their fully owned submissive.
-		if (    data.Action === "UpdateNotes"
-		    &&  TargetAcc.Ownership != null
-		    &&  TargetAcc.Ownership.Stage === 1
-		    &&  TargetAcc.Ownership.MemberNumber == Acc.MemberNumber)
-		{
-			if (typeof data.Notes === "string"  &&  data.Notes.length > 0) {
+		if (
+			data.Action === "UpdateNotes"
+			&& TargetAcc.Ownership != null
+			&& TargetAcc.Ownership.Stage === 1
+			&& TargetAcc.Ownership.MemberNumber == Acc.MemberNumber
+		) {
+			if (typeof data.Notes === "string" && data.Notes.length > 0) {
 				// FIXME: This isn't fully Unicode-aware.
-				TargetAcc.Ownership.Notes = data.Notes.slice (0, 10000);
+				TargetAcc.Ownership.Notes = data.Notes.slice(0, 10000);
 			} else {
 				TargetAcc.Ownership.Notes = undefined;
 			}
 			let O = { Ownership: TargetAcc.Ownership, Owner: TargetAcc.Owner };
-			Database.collection(AccountCollection).updateOne (
+			Database.collection(AccountCollection).updateOne(
 				{ AccountName: TargetAcc.AccountName },
 				{ $set: O },
-				function (err, _res) {
+				function(err, _res) {
 					if (err) throw err;
-					socket.emit ("AccountOwnership", O);
-					ChatRoomSyncCharacter (Acc.ChatRoom, TargetAcc.MemberNumber, TargetAcc.MemberNumber);
+					socket.emit("AccountOwnership", O);
+					ChatRoomSyncCharacter(Acc.ChatRoom, TargetAcc.MemberNumber, TargetAcc.MemberNumber);
 				});
 			return;
 		}

--- a/app.js
+++ b/app.js
@@ -2326,7 +2326,7 @@ function AccountOwnership(data, socket) {
 				Acc.Owner = "";
 				Acc.Ownership = null;
 				let O = { Ownership: Acc.Ownership, Owner: Acc.Owner };
-				Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, _res) { if (err) throw err; });
+				Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
 				socket.emit("AccountOwnership", { ClearOwnership: true });
 				return;
 			}
@@ -2343,7 +2343,7 @@ function AccountOwnership(data, socket) {
 			Database.collection(AccountCollection).findOne({ MemberNumber : data.MemberNumber }, function(err, result) {
 				if (err) throw err;
 				if ((result != null) && (result.MemberNumber != null) && (result.MemberNumber === data.MemberNumber) && (result.Ownership != null) && (result.Ownership.MemberNumber === Acc.MemberNumber)) {
-					Database.collection(AccountCollection).updateOne({ AccountName : result.AccountName }, { $set: { Owner: "", Ownership: null } }, function(err, _res) { if (err) throw err; });
+					Database.collection(AccountCollection).updateOne({ AccountName : result.AccountName }, { $set: { Owner: "", Ownership: null } }, function(err, res) { if (err) throw err; });
 					ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "ReleaseSuccess", "ServerMessage", Acc.MemberNumber);
 					let Target = Account.find(A => A.MemberNumber === data.MemberNumber);
 					if (!Target) return;
@@ -2369,18 +2369,21 @@ function AccountOwnership(data, socket) {
 		    &&  TargetAcc.Ownership != null
 		    &&  TargetAcc.Ownership.MemberNumber == Acc.MemberNumber)
 		{
-			if (data.Notes != null  &&  typeof data.Notes === "string"  &&  data.Notes.length > 0) {
+			if (typeof data.Notes === "string"  &&  data.Notes.length > 0) {
 				// FIXME: This isn't fully Unicode-aware.
 				TargetAcc.Ownership.Notes = data.Notes.slice (0, 10000);
 			} else {
 				TargetAcc.Ownership.Notes = null;
 			}
 			let O = { Ownership: TargetAcc.Ownership, Owner: TargetAcc.Owner };
-			Database.collection(AccountCollection).updateOne ({ AccountName: TargetAcc.AccountName },
-			                                                  { $set: O },
-			                                                  function (err, _res) { if (err) throw err; });
-			socket.emit ("AccountOwnership", O);
-			ChatRoomSyncCharacter (Acc.ChatRoom, TargetAcc.MemberNumber, TargetAcc.MemberNumber);
+			Database.collection(AccountCollection).updateOne (
+				{ AccountName: TargetAcc.AccountName },
+				{ $set: O },
+				function (err, _res) {
+					if (err) throw err;
+					socket.emit ("AccountOwnership", O);
+					ChatRoomSyncCharacter (Acc.ChatRoom, TargetAcc.MemberNumber, TargetAcc.MemberNumber);
+				});
 			return;
 		}
 
@@ -2390,7 +2393,7 @@ function AccountOwnership(data, socket) {
 			TargetAcc.Owner = "";
 			TargetAcc.Ownership = null;
 			let O = { Ownership: TargetAcc.Ownership, Owner: TargetAcc.Owner };
-			Database.collection(AccountCollection).updateOne({ AccountName : TargetAcc.AccountName }, { $set: O }, function(err, _res) { if (err) throw err; });
+			Database.collection(AccountCollection).updateOne({ AccountName : TargetAcc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
 			TargetAcc.Socket.emit("AccountOwnership", { ClearOwnership: true });
 			ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, isTrial ? "EndOwnershipTrial" : "EndOwnership", "ServerMessage", null, [
 				{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber },
@@ -2454,7 +2457,7 @@ function AccountOwnership(data, socket) {
 						Acc.Owner = "";
 						Acc.Ownership = { MemberNumber: data.MemberNumber, Name: TargetAcc.Name, Start: CommonTime(), Stage: 0 };
 						let O = { Ownership: Acc.Ownership, Owner: Acc.Owner };
-						Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, _res) { if (err) throw err; });
+						Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
 						socket.emit("AccountOwnership", O);
 						ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "StartTrial", "ServerMessage", null, [{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber }]);
 						ChatRoomSyncCharacter(Acc.ChatRoom, Acc.MemberNumber, Acc.MemberNumber);
@@ -2471,7 +2474,7 @@ function AccountOwnership(data, socket) {
 						Acc.Owner = TargetAcc.Name;
 						Acc.Ownership = { MemberNumber: data.MemberNumber, Name: TargetAcc.Name, Start: CommonTime(), Stage: 1 };
 						let O = { Ownership: Acc.Ownership, Owner: Acc.Owner };
-						Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, _res) { if (err) throw err; });
+						Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
 						socket.emit("AccountOwnership", O);
 						ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "EndTrial", "ServerMessage", null, [{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber }]);
 						ChatRoomSyncCharacter(Acc.ChatRoom, Acc.MemberNumber, Acc.MemberNumber);

--- a/app.js
+++ b/app.js
@@ -2326,7 +2326,7 @@ function AccountOwnership(data, socket) {
 				Acc.Owner = "";
 				Acc.Ownership = null;
 				let O = { Ownership: Acc.Ownership, Owner: Acc.Owner };
-				Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
+				Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, _res) { if (err) throw err; });
 				socket.emit("AccountOwnership", { ClearOwnership: true });
 				return;
 			}
@@ -2343,7 +2343,7 @@ function AccountOwnership(data, socket) {
 			Database.collection(AccountCollection).findOne({ MemberNumber : data.MemberNumber }, function(err, result) {
 				if (err) throw err;
 				if ((result != null) && (result.MemberNumber != null) && (result.MemberNumber === data.MemberNumber) && (result.Ownership != null) && (result.Ownership.MemberNumber === Acc.MemberNumber)) {
-					Database.collection(AccountCollection).updateOne({ AccountName : result.AccountName }, { $set: { Owner: "", Ownership: null } }, function(err, res) { if (err) throw err; });
+					Database.collection(AccountCollection).updateOne({ AccountName : result.AccountName }, { $set: { Owner: "", Ownership: null } }, function(err, _res) { if (err) throw err; });
 					ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "ReleaseSuccess", "ServerMessage", Acc.MemberNumber);
 					let Target = Account.find(A => A.MemberNumber === data.MemberNumber);
 					if (!Target) return;
@@ -2356,11 +2356,33 @@ function AccountOwnership(data, socket) {
 					}
 				} else ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "ReleaseFail", "ServerMessage", Acc.MemberNumber);
 			});
-
 		}
+
 
 		// Exit if there's no target
 		if (!TargetAcc) return;
+
+		// The dominant is setting/updating public notes on their submissive.
+		if (    data.Action === "UpdateNotes"
+		    &&  TargetAcc.Owner != null
+		    &&  TargetAcc.Owner !== ""
+		    &&  TargetAcc.Ownership != null
+		    &&  TargetAcc.Ownership.MemberNumber == Acc.MemberNumber)
+		{
+			if (data.Notes != null  &&  typeof data.Notes === "string"  &&  data.Notes.length > 0) {
+				// FIXME: This isn't fully Unicode-aware.
+				TargetAcc.Ownership.Notes = data.Notes.slice (0, 10000);
+			} else {
+				TargetAcc.Ownership.Notes = null;
+			}
+			let O = { Ownership: TargetAcc.Ownership, Owner: TargetAcc.Owner };
+			Database.collection(AccountCollection).updateOne ({ AccountName: TargetAcc.AccountName },
+			                                                  { $set: O },
+			                                                  function (err, _res) { if (err) throw err; });
+			socket.emit ("AccountOwnership", O);
+			ChatRoomSyncCharacter (Acc.ChatRoom, TargetAcc.MemberNumber, TargetAcc.MemberNumber);
+			return;
+		}
 
 		// The dominant can release the submissive player at any time
 		if (data.Action === "Release" && TargetAcc.Ownership != null && TargetAcc.Ownership.MemberNumber === Acc.MemberNumber) {
@@ -2368,7 +2390,7 @@ function AccountOwnership(data, socket) {
 			TargetAcc.Owner = "";
 			TargetAcc.Ownership = null;
 			let O = { Ownership: TargetAcc.Ownership, Owner: TargetAcc.Owner };
-			Database.collection(AccountCollection).updateOne({ AccountName : TargetAcc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
+			Database.collection(AccountCollection).updateOne({ AccountName : TargetAcc.AccountName }, { $set: O }, function(err, _res) { if (err) throw err; });
 			TargetAcc.Socket.emit("AccountOwnership", { ClearOwnership: true });
 			ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, isTrial ? "EndOwnershipTrial" : "EndOwnership", "ServerMessage", null, [
 				{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber },
@@ -2432,7 +2454,7 @@ function AccountOwnership(data, socket) {
 						Acc.Owner = "";
 						Acc.Ownership = { MemberNumber: data.MemberNumber, Name: TargetAcc.Name, Start: CommonTime(), Stage: 0 };
 						let O = { Ownership: Acc.Ownership, Owner: Acc.Owner };
-						Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
+						Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, _res) { if (err) throw err; });
 						socket.emit("AccountOwnership", O);
 						ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "StartTrial", "ServerMessage", null, [{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber }]);
 						ChatRoomSyncCharacter(Acc.ChatRoom, Acc.MemberNumber, Acc.MemberNumber);
@@ -2449,7 +2471,7 @@ function AccountOwnership(data, socket) {
 						Acc.Owner = TargetAcc.Name;
 						Acc.Ownership = { MemberNumber: data.MemberNumber, Name: TargetAcc.Name, Start: CommonTime(), Stage: 1 };
 						let O = { Ownership: Acc.Ownership, Owner: Acc.Owner };
-						Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, res) { if (err) throw err; });
+						Database.collection(AccountCollection).updateOne({ AccountName : Acc.AccountName }, { $set: O }, function(err, _res) { if (err) throw err; });
 						socket.emit("AccountOwnership", O);
 						ChatRoomMessage(Acc.ChatRoom, Acc.MemberNumber, "EndTrial", "ServerMessage", null, [{ Tag: "SourceCharacter", Text: Acc.Name, MemberNumber: Acc.MemberNumber }]);
 						ChatRoomSyncCharacter(Acc.ChatRoom, Acc.MemberNumber, Acc.MemberNumber);

--- a/app.js
+++ b/app.js
@@ -2370,7 +2370,7 @@ function AccountOwnership(data, socket) {
 		) {
 			if (typeof data.Notes === "string" && data.Notes.length > 0) {
 				// FIXME: This isn't fully Unicode-aware.
-				TargetAcc.Ownership.Notes = data.Notes.slice(0, 10000);
+				TargetAcc.Ownership.Notes = data.Notes.slice(0, 4000);
 			} else {
 				TargetAcc.Ownership.Notes = undefined;
 			}

--- a/app.js
+++ b/app.js
@@ -2380,8 +2380,8 @@ function AccountOwnership(data, socket) {
 				{ $set: O },
 				function(err, _res) {
 					if (err) throw err;
-					socket.emit("AccountOwnership", O);
-					ChatRoomSyncCharacter(Acc.ChatRoom, TargetAcc.MemberNumber, TargetAcc.MemberNumber);
+					TargetAcc.Socket.emit("AccountOwnership", O);
+					ChatRoomSyncCharacter(TargetAcc.ChatRoom, TargetAcc.MemberNumber, TargetAcc.MemberNumber);
 				});
 			return;
 		}


### PR DESCRIPTION
The owner of a submissive may now "pin a note" to them ("If found, return to...", "Do not remove $(ITEM_LIST)...," "Is being disciplined for...," etc.).  The note is free-form (compressed) text stored in the Ownership struct, and is displayed in the user's OnlineProfile pane.

Create a new Ownership property: `Notes`.  If the updated note has zero length, the property is set to null.

Create a new Message request type: `ServerAccountOwnershipUpdateNotesRequest`.