### PR TITLE
ENH: Let `OnlineFriends` queries also return the room size- and occupancy

### DIFF
--- a/Messages.d.ts
+++ b/Messages.d.ts
@@ -340,6 +340,7 @@ interface ServerFriendInfo {
     Type: "Friend" | "Submissive" | "Lover";
     MemberNumber: number;
     MemberName: string;
+	MemberNickname?: string;
     ChatRoomSpace?: ServerChatRoomSpace | null;
     ChatRoomName?: string | null;
     ChatRoomLimit?: number;

--- a/Messages.d.ts
+++ b/Messages.d.ts
@@ -342,6 +342,8 @@ interface ServerFriendInfo {
     MemberName: string;
     ChatRoomSpace?: ServerChatRoomSpace | null;
     ChatRoomName?: string | null;
+    ChatRoomLimit?: number;
+    ChatRoomMemberCount?: number;
     Private?: true | undefined;
 }
 

--- a/app.js
+++ b/app.js
@@ -919,6 +919,7 @@ function AccountQueryGetFriendInfo(type, account) {
 		Type: type,
 		MemberNumber: account.MemberNumber,
 		MemberName: account.Name,
+		MemberNickname: account.Nickname,
 	};
 	chatRoom: if (account.ChatRoom) {
 		if (ChatRoomRoleListIsRestrictive(account.ChatRoom.Visibility)) {

--- a/app.js
+++ b/app.js
@@ -908,6 +908,35 @@ function AccountUpdateEmail(data, socket) {
 }
 
 /**
+ * Construct the friend info associated with the passed account
+ * @param {"Submissive" | "Lover" | "Friend"} type The type of friend
+ * @param {Account} account The friend account
+ * @returns {ServerFriendInfo} The `OnlineFriends` query friend info
+ */
+function AccountQueryGetFriendInfo(type, account) {
+	/** @type {ServerFriendInfo} */
+	const friendInfo = {
+		Type: type,
+		MemberNumber: account.MemberNumber,
+		MemberName: account.Name,
+	};
+	chatRoom: if (account.ChatRoom) {
+		if (ChatRoomRoleListIsRestrictive(account.ChatRoom.Visibility)) {
+			friendInfo.Private = true;
+			if (type === "Friend") {
+				// Do not show any further private room info for normal friends; only do so for lovers and submissives
+				break chatRoom;
+			}
+		}
+		friendInfo.ChatRoomSpace = account.ChatRoom.Space;
+		friendInfo.ChatRoomName = account.ChatRoom.Name;
+		friendInfo.ChatRoomMemberCount = account.ChatRoom.Account.length;
+		friendInfo.ChatRoomLimit = account.ChatRoom.Limit;
+	}
+	return friendInfo;
+}
+
+/**
  * When the client account sends a query to the server
  * @param {ServerAccountQueryRequest} data
  * @param {ServerSocket} socket
@@ -935,7 +964,7 @@ function AccountQuery(data, socket) {
 						var IsOwned = (OtherAcc.Ownership != null) && (OtherAcc.Ownership.MemberNumber != null) && (OtherAcc.Ownership.MemberNumber == Acc.MemberNumber);
 						var IsLover = LoversNumbers.indexOf(Acc.MemberNumber) >= 0;
 						if (IsOwned || IsLover) {
-							Friends.push({ Type: IsOwned ? "Submissive" : "Lover", MemberNumber: OtherAcc.MemberNumber, MemberName: OtherAcc.Name, ChatRoomSpace: (OtherAcc.ChatRoom == null) ? null : OtherAcc.ChatRoom.Space, ChatRoomName: (OtherAcc.ChatRoom == null) ? null : OtherAcc.ChatRoom.Name, Private: (OtherAcc.ChatRoom && ChatRoomRoleListIsRestrictive(OtherAcc.ChatRoom.Visibility)) ? true : undefined });
+							Friends.push(AccountQueryGetFriendInfo(IsOwned ? "Submissive" : "Lover", OtherAcc));
 							Index.push(OtherAcc.MemberNumber);
 						}
 					}
@@ -948,7 +977,7 @@ function AccountQuery(data, socket) {
 							for (const OtherAcc of Account)
 								if (OtherAcc.MemberNumber == Acc.FriendList[F]) {
 									if ((OtherAcc.Environment == Acc.Environment) && (OtherAcc.FriendList != null) && (OtherAcc.FriendList.indexOf(Acc.MemberNumber) >= 0))
-										Friends.push({ Type: "Friend", MemberNumber: OtherAcc.MemberNumber, MemberName: OtherAcc.Name, ChatRoomSpace: ((OtherAcc.ChatRoom != null) && !ChatRoomRoleListIsRestrictive(OtherAcc.ChatRoom.Visibility)) ? OtherAcc.ChatRoom.Space : null, ChatRoomName: (OtherAcc.ChatRoom == null) ? null : (ChatRoomRoleListIsRestrictive(OtherAcc.ChatRoom.Visibility)) ? null : OtherAcc.ChatRoom.Name, Private: (OtherAcc.ChatRoom && ChatRoomRoleListIsRestrictive(OtherAcc.ChatRoom.Visibility)) ? true : undefined });
+										Friends.push(AccountQueryGetFriendInfo("Friend", OtherAcc));
 									break;
 								}
 


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#6243](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6243)

This PR updates the `OnlineFriends` in order to let it expose the room size- and occupancy for non-private rooms. The relevant data was already available previously to the server, but was never communicated back to the client.