### PR TITLE
Make a null Nickname unset the nickname entirely

### DIFF
--- a/app.js
+++ b/app.js
@@ -180,7 +180,7 @@ const ServerAccountNameRegex = /^[a-zA-Z0-9]{1,20}$/;
 const ServerAccountPasswordRegex = /^[a-zA-Z0-9]{1,20}$/;
 const ServerAccountResetNumberRegex = /^[0-9]{1,20}$/;
 const ServerCharacterNameRegex = /^[a-zA-Z ]{1,20}$/;
-const ServerCharacterNicknameRegex = /^[\p{L}\p{Nd}\p{Z}'-]+$/u;
+const ServerCharacterNicknameRegex = /^[\p{L}\p{Nd}\p{Z}'\-]{1,20}$/u;
 const ServerChatRoomNameRegex = /^[\x20-\x7E]{1,20}$/;
 const ServerChatMessageMaxLength = 2000;
 const ServerChatRoomDescriptionMaxLength = 300;
@@ -805,7 +805,11 @@ function AccountUpdate(data, socket) {
 					delete data.Lover;
 				}
 				if ((data.Title != null)) Acc.Title = data.Title;
-				if ((data.Nickname != null)) Acc.Nickname = data.Nickname;
+				if (data.Nickname === null) {
+					Acc.Nickname = null;
+				} else if (typeof data.Nickname === "string" && data.Nickname.match(ServerCharacterNicknameRegex)) {
+					Acc.Nickname = data.Nickname;
+				}
 				if ((data.Crafting != null)) Acc.Crafting = data.Crafting;
 
 				// Some changes should be synched to other players in chatroom


### PR DESCRIPTION
Also validate nicknames with the regex.

This fixes an issue where the client would send a `null` Nickname, asking for the nickname to be deleted, but the server would ignore that because of the loose null check, leading to everyone else not getting the memo that the character name should be used now.