### PR TITLE
Do a proper sync in case a nickname is deleted

### DIFF
--- a/app.js
+++ b/app.js
@@ -813,7 +813,8 @@ function AccountUpdate(data, socket) {
 				if ((data.Crafting != null)) Acc.Crafting = data.Crafting;
 
 				// Some changes should be synched to other players in chatroom
-				if ((Acc != null) && Acc.ChatRoom && /** @type {(keyof Account)[]} */ (["MapData", "Title", "Nickname", "Crafting", "Reputation", "Description", "LabelColor", "ItemPermission", "InventoryData", "BlockItems", "LimitedItems", "FavoriteItems", "OnlineSharedSettings", "WhiteList", "BlackList"]).some(k => data[k] != null))
+				const shouldSync = /** @type {(keyof Account)[]} */ (["MapData", "Title", "Nickname", "Crafting", "Reputation", "Description", "LabelColor", "ItemPermission", "InventoryData", "BlockItems", "LimitedItems", "FavoriteItems", "OnlineSharedSettings", "WhiteList", "BlackList"]).some(k => k in data);
+				if ((Acc != null) && Acc.ChatRoom && shouldSync)
 					ChatRoomSyncCharacter(Acc.ChatRoom, Acc.MemberNumber, Acc.MemberNumber);
 
 				// If only the appearance is updated, we keep the change in memory and do not update the database right away


### PR DESCRIPTION
The loose null check made it not sync after receiving a `Nickname: null` entry. Fix the issue by instead checking for key existence instead of value.